### PR TITLE
Update filevault-package-maven-plugin to version 1.0.3

### DIFF
--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -202,7 +202,7 @@
                 <plugin>
                     <groupId>org.apache.jackrabbit</groupId>
                     <artifactId>filevault-package-maven-plugin</artifactId>
-                    <version>1.0.1</version>
+                    <version>1.0.3</version>
                     <configuration>
                         <filterSource>src/main/content/META-INF/vault/filter.xml</filterSource>
                     </configuration>


### PR DESCRIPTION
This bring in multiple fixes, notably [JCRVLT-272](https://issues.apache.org/jira/browse/JCRVLT-272) which caused `mvn test` to fail in multi-module builds.

This fixes  #161

## Description

Plugin version update to latest stable release.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.