### PR TITLE
Use AEM Mocks instead of Sling Mocks

### DIFF
--- a/src/main/archetype/core/pom.xml
+++ b/src/main/archetype/core/pom.xml
@@ -127,8 +127,8 @@
             <artifactId>junit-addons</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
+            <groupId>io.wcm.</groupId>
+            <artifactId>io.wcm.testing.aem-mock.junit4</artifactId>
         </dependency>
         <dependency>
             <groupId>uk.org.lidalia</groupId>

--- a/src/main/archetype/core/src/main/java/core/models/HelloWorldModel.java
+++ b/src/main/archetype/core/src/main/java/core/models/HelloWorldModel.java
@@ -15,35 +15,52 @@
  */
 package ${package}.core.models;
 
+import static org.apache.sling.api.resource.ResourceResolver.PROPERTY_RESOURCE_TYPE;
+
 import javax.annotation.PostConstruct;
-import javax.inject.Inject;
-import javax.inject.Named;
 
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.jcr.resource.api.JcrResourceConstants;
+import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.models.annotations.Default;
 import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
+import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+import org.apache.sling.models.annotations.injectorspecific.SlingObject;
+import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 import org.apache.sling.settings.SlingSettingsService;
 
-@Model(adaptables=Resource.class)
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageManager;
+
+@Model(adaptables = Resource.class)
 public class HelloWorldModel {
 
-    @Inject
-    private SlingSettingsService settings;
-
-    @Inject @Named(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY) @Default(values="No resourceType")
+    @ValueMapValue(name=PROPERTY_RESOURCE_TYPE, injectionStrategy=InjectionStrategy.OPTIONAL)
+    @Default(values="No resourceType")
     protected String resourceType;
+
+    @OSGiService
+    private SlingSettingsService settings;
+    @SlingObject
+    private Resource currentResource;
+    @SlingObject
+    private ResourceResolver resourceResolver;
 
     private String message;
 
     @PostConstruct
     protected void init() {
-        message = "\tHello World!\n";
-        message += "\tThis is instance: " + settings.getSlingId() + "\n";
-        message += "\tResource type is: " + resourceType + "\n";
+        PageManager pageManager = resourceResolver.adaptTo(PageManager.class);
+        Page currentPage = pageManager.getContainingPage(currentResource);
+
+        message = "\tHello World!\n"
+            + "\tThis is instance: " + settings.getSlingId() + "\n"
+            + "\tResource type is: " + resourceType + "\n"
+            + "\tCurrent page is: " + (currentPage != null ? currentPage.getPath() : "") + "\n";
     }
 
     public String getMessage() {
         return message;
     }
+
 }

--- a/src/main/archetype/core/src/test/java/core/filters/LoggingFilterTest.java
+++ b/src/main/archetype/core/src/test/java/core/filters/LoggingFilterTest.java
@@ -15,12 +15,12 @@
  */
 package ${package}.core.filters;
 
-import org.apache.sling.testing.mock.sling.junit.SlingContext;
 import org.apache.sling.testing.mock.sling.servlet.MockRequestPathInfo;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletResponse;
 import org.junit.Rule;
 import org.junit.Test;
+import io.wcm.testing.mock.aem.junit.AemContext;
 import uk.org.lidalia.slf4jext.Level;
 import uk.org.lidalia.slf4jtest.LoggingEvent;
 import uk.org.lidalia.slf4jtest.TestLogger;
@@ -40,7 +40,7 @@ import static org.junit.Assert.*;
 public class LoggingFilterTest {
 
     @Rule
-    public final SlingContext context = new SlingContext();
+    public final AemContext context = new AemContext();
 
     @Rule
     public final TestLoggerFactoryResetRule testLoggerFactoryResetRule = new TestLoggerFactoryResetRule();

--- a/src/main/archetype/core/src/test/java/core/models/HelloWorldModelTest.java
+++ b/src/main/archetype/core/src/test/java/core/models/HelloWorldModelTest.java
@@ -17,44 +17,49 @@ package ${package}.core.models;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-import java.util.UUID;
-
-import junitx.util.PrivateAccessor;
-
-import org.apache.sling.settings.SlingSettingsService;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.resource.Resource;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+
+import com.day.cq.wcm.api.Page;
+
+import io.wcm.testing.mock.aem.junit.AemContext;
 
 /**
  * Simple JUnit test verifying the HelloWorldModel
  */
 public class HelloWorldModelTest {
 
-    //@Inject
+    @Rule
+    public final AemContext context = new AemContext();
+
     private HelloWorldModel hello;
-    
-    private String slingId;
-    
+
+    private Page page;
+    private Resource resource;
+
     @Before
     public void setup() throws Exception {
-        SlingSettingsService settings = mock(SlingSettingsService.class);
-        slingId = UUID.randomUUID().toString();
-        when(settings.getSlingId()).thenReturn(slingId);
 
-        hello = new HelloWorldModel();
-        PrivateAccessor.setField(hello, "settings", settings);
-        hello.init();
+        // prepare a page with a test resource
+        page = context.create().page("/content/mypage");
+        resource = context.create().resource(page, "hello",
+            "sling:resourceType", "${appsFolderName}/components/content/helloworld");
+
+        // create sling model
+        hello = resource.adaptTo(HelloWorldModel.class);
     }
-    
+
     @Test
     public void testGetMessage() throws Exception {
         // some very basic junit tests
         String msg = hello.getMessage();
         assertNotNull(msg);
-        assertTrue(msg.length() > 0);
+        assertTrue(StringUtils.contains(msg, resource.getResourceType()));
+        assertTrue(StringUtils.contains(msg, page.getPath()));
     }
 
 }

--- a/src/main/archetype/core/src/test/java/core/servlets/SimpleServletTest.java
+++ b/src/main/archetype/core/src/test/java/core/servlets/SimpleServletTest.java
@@ -15,7 +15,6 @@
  */
 package ${package}.core.servlets;
 
-import org.apache.sling.testing.mock.sling.junit.SlingContext;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletResponse;
 import org.junit.Rule;
@@ -24,12 +23,14 @@ import org.junit.Test;
 import javax.servlet.ServletException;
 import java.io.IOException;
 
+import io.wcm.testing.mock.aem.junit.AemContext;
+
 import static org.junit.Assert.*;
 
 public class SimpleServletTest {
 
     @Rule
-    public final SlingContext context = new SlingContext();
+    public final AemContext context = new AemContext();
 
     private SimpleServlet fixture = new SimpleServlet();
 

--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -610,9 +610,9 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.apache.sling</groupId>
-                <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
-                <version>2.3.4</version>
+                <groupId>io.wcm.</groupId>
+                <artifactId>io.wcm.testing.aem-mock.junit4</artifactId>
+                <version>2.4.4</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
As this is an archetype for AEM projects and not only for Sling projects it would be very useful for the users to include AEM mocks by default, and not only Sling Mocks.
With only Sling Mocks it's difficult to test code that depends on the AEM API.

## How Has This Been Tested?

Ensured that all includes unit tests still run, and AEM Mocks can be used in the unit tests.
