### PR TITLE
Update to aem-mock 2.4.8

### DIFF
--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -619,7 +619,7 @@
             <dependency>
                 <groupId>io.wcm</groupId>
                 <artifactId>io.wcm.testing.aem-mock.junit5</artifactId>
-                <version>2.4.4</version>
+                <version>2.4.8</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Update from 2.4.4 to 2.4.8

aem-mock 2.4.8 includes some improvements to be more compatible with the latest AEM 6.5.0 uber jar.