### PR TITLE
Add experience fragments for header footer

### DIFF
--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/structure/page/customfooterlibs.html
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/structure/page/customfooterlibs.html
@@ -16,3 +16,8 @@
 <sly data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html">
     <sly data-sly-call="${symbol_dollar}{clientlib.js @ categories='${cssId}.base'}"/>
 </sly>
+<script type="text/javascript">
+	if (typeof _satellite != "undefined") {
+		_satellite.pageBottom();
+	}
+</script> 

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/structure/page/customheaderlibs.html
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/structure/page/customheaderlibs.html
@@ -18,3 +18,18 @@
 
 <!--/* Include Context Hub */-->
 <sly data-sly-resource="${symbol_dollar}{'contexthub' @ resourceType='granite/contexthub/components/contexthub'}"/>
+<!--/* Data layer JavaScript object: */-->
+<script>
+  var digitalData = {};
+  digitalData = {
+		  		  page: {
+		  			  pageInfo: {
+		  				  pageName: '${symbol_dollar}{currentPage.name @context="scriptString"}',
+		  				  pageURL : '${symbol_dollar}{currentPage.path @context="uri"}',
+		  				  pageType: '${symbol_dollar}{currentPage.name @context="scriptString"}',
+		  				  siteName: '${symbol_dollar}{request.serverName @context="scriptString"}'
+		  			  },
+  visitorProfile: {}
+   }
+
+</script>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/structure/xfpage/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/structure/xfpage/.content.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:description="Page with ${siteName} specific components for Experience Fragments web variations"
+    jcr:primaryType="cq:Component"
+    jcr:title="${siteName} Experience Fragment Web Variation Page"
+    sling:resourceSuperType="cq/experience-fragments/components/xfpage"
+    componentGroup=".hidden"/>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/structure/xfpage/body.html
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/structure/xfpage/body.html
@@ -1,0 +1,7 @@
+<div class="container">
+    <sly data-sly-use.templatedContainer="com.day.cq.wcm.foundation.TemplatedContainer"
+         data-sly-repeat.child="${symbol_dollar}{templatedContainer.structureResources}"
+         data-sly-resource="${symbol_dollar}{child.path @ resourceType=child.resourceType, decorationTagName='div'}"></sly>
+</div>
+<sly data-sly-resource="${symbol_dollar}{'cloudservices' @ resourceType='cq/cloudserviceconfigs/components/servicecomponents'}"></sly>
+<sly data-sly-include="footerlibs.html"></sly>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/structure/xfpage/customfooterlibs.html
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/structure/xfpage/customfooterlibs.html
@@ -1,0 +1,5 @@
+<sly data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html">
+    <sly data-sly-call="${symbol_dollar}{clientlib.js @ categories='${cssId}.base'}"/>
+    <!--/* Load authoring related client libraries */-->
+    <sly data-sly-test="${symbol_dollar}{wcmmode.preview || wcmmode.edit}" data-sly-call="${symbol_dollar}{clientLib.js @ categories='${cssId}.authoring'}"/>
+</sly>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/structure/xfpage/customheaderlibs.html
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/structure/xfpage/customheaderlibs.html
@@ -1,0 +1,10 @@
+<sly data-sly-use.clientLib="/libs/granite/sightly/templates/clientlib.html"
+     data-sly-call="${symbol_dollar}{clientlib.css @ categories='${cssId}.base'}"/>
+
+<!--/* Initialize TypeKit Fonts */-->
+<script src="https://use.typekit.net/dje4ayd.js"></script>
+<script>try {
+    Typekit.load({async: true});
+} catch (e) {
+}</script>
+

--- a/src/main/archetype/ui.content/src/main/content/META-INF/vault/filter.xml
+++ b/src/main/archetype/ui.content/src/main/content/META-INF/vault/filter.xml
@@ -3,4 +3,5 @@
     <filter root="/conf/${confFolderName}" mode="merge"/>
     <filter root="/content/${contentFolderName}" mode="merge"/>
     <filter root="/content/dam/${contentFolderName}" mode="merge"/>
+    <filter root="/content/experience-fragments/${contentFolderName}" mode="merge"/>
 </workspaceFilter>

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/policies/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/policies/.content.xml
@@ -12,7 +12,7 @@
                         jcr:primaryType="nt:unstructured"
                         jcr:title="${siteName} Default"
                         sling:resourceType="wcm/core/components/policy/policy"
-                        components="[group:${componentGroupName},/apps/${appsFolderName}/components/form/container]"
+                        components="[group:${componentGroupName},/apps/${appsFolderName}/components/form/container,/libs/dam/cfm/components/contentfragment,/libs/cq/experience-fragments/editor/components/experiencefragment,/libs/wcm/foundation/components/responsivegrid]"
                         policyResourceType="wcm/foundation/components/responsivegrid">
                         <cq:authoring jcr:primaryType="nt:unstructured">
                             <assetToComponentMapping jcr:primaryType="nt:unstructured">

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/template-types/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/template-types/.content.xml
@@ -2,5 +2,6 @@
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:rep="internal"
     jcr:primaryType="cq:Page">
     <empty-page/>
+    <empty-experience-fragment/>
     <rep:policy/>
 </jcr:root>

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/template-types/empty-experience-fragment/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/template-types/empty-experience-fragment/.content.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:mix="http://www.jcp.org/jcr/mix/1.0"
+    jcr:mixinTypes="[mix:lockable]"
+    jcr:primaryType="cq:Template"
+    ranking="{Long}1">
+    <jcr:content
+        jcr:description="Generic template for empty experience fragments variations"
+        jcr:primaryType="cq:PageContent"
+        jcr:title="${siteName} Empty Experience Fragment"
+        status="draft"/>
+</jcr:root>

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/template-types/empty-experience-fragment/initial/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/template-types/empty-experience-fragment/initial/.content.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        cq:template="/conf/${confFolderName}/settings/wcm/templates/empty-experience-fragment"
+        jcr:primaryType="cq:PageContent"
+        sling:resourceType="${appsFolderName}/components/structure/xfpage"/>
+</jcr:root>

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/template-types/empty-experience-fragment/policies/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/template-types/empty-experience-fragment/policies/.content.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="wcm/core/components/policies/mappings">
+        <root
+            cq:policy="wcm/foundation/components/responsivegrid/content-default"
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="wcm/core/components/policies/mapping"/>
+    </jcr:content>
+</jcr:root>

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/template-types/empty-experience-fragment/structure/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/template-types/empty-experience-fragment/structure/.content.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        cq:deviceGroups="[mobile/groups/responsive]"
+        cq:template="/conf/${confFolderName}/settings/wcm/templates/empty-experience-fragment"
+        jcr:primaryType="cq:PageContent"
+        sling:resourceType="${appsFolderName}/components/structure/page">
+        <root
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="wcm/foundation/components/responsivegrid"/>
+        <cq:responsive jcr:primaryType="nt:unstructured">
+            <breakpoints jcr:primaryType="nt:unstructured">
+                <phone
+                    jcr:primaryType="nt:unstructured"
+                    title="Smaller Screen"
+                    width="{Long}650"/>
+                <tablet
+                    jcr:primaryType="nt:unstructured"
+                    title="Tablet"
+                    width="{Long}1200"/>
+            </breakpoints>
+        </cq:responsive>
+    </jcr:content>
+</jcr:root>

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/.content.xml
@@ -3,5 +3,8 @@
     jcr:mixinTypes="[rep:AccessControllable]"
     jcr:primaryType="cq:Page">
     <content-page/>
+    <landing-page/>
+    <homepage/>
+    <experience-fragment-web-variation/>
     <rep:policy/>
 </jcr:root>

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/experience-fragment-web-variation/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/experience-fragment-web-variation/.content.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Template">
+    <jcr:content
+        cq:lastModified="{Date}2017-04-19T17:41:01.195+02:00"
+        cq:lastModifiedBy="admin"
+        cq:templateType="/conf/${confFolderName}/settings/wcm/template-types/empty-experience-fragment"
+        jcr:primaryType="cq:PageContent"
+        jcr:title="${siteName} Experience Fragment Web Variation"
+        status="enabled"/>
+</jcr:root>

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/experience-fragment-web-variation/initial/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/experience-fragment-web-variation/initial/.content.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        cq:template="/conf/${confFolderName}/settings/wcm/templates/experience-fragment-web-variation"
+        cq:xfVariantType="web"
+        jcr:primaryType="cq:PageContent"
+        jcr:title="Web"
+        sling:resourceType="${appsFolderName}/components/structure/xfpage">
+        <root
+            jcr:lastModified="{Date}2016-11-22T17:31:48.669+02:00"
+            jcr:lastModifiedBy="admin"
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="wcm/foundation/components/responsivegrid"/>
+    </jcr:content>
+</jcr:root>

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/experience-fragment-web-variation/policies/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/experience-fragment-web-variation/policies/.content.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="wcm/core/components/policies/mappings">
+        <root
+            cq:policy="wcm/foundation/components/responsivegrid/content-default"
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="wcm/core/components/policies/mapping">
+            <responsivegrid
+                cq:policy="wcm/foundation/components/responsivegrid/content-default"
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="wcm/core/components/policies/mapping">
+                <${appsFolderName} jcr:primaryType="nt:unstructured">
+                    <components jcr:primaryType="nt:unstructured">
+                        <form jcr:primaryType="nt:unstructured">
+                            <container
+                                cq:policy="${appsFolderName}/components/form/container/form-container"
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="wcm/core/components/policies/mapping"/>
+                        </form>
+                    </components>
+                </${appsFolderName}>
+            </responsivegrid>
+        </root>
+    </jcr:content>
+</jcr:root>

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/experience-fragment-web-variation/structure/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/experience-fragment-web-variation/structure/.content.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        cq:deviceGroups="[mobile/groups/responsive]"
+        cq:template="/conf/${confFolderName}/settings/wcm/templates/experience-fragment-web-variation"
+        jcr:primaryType="cq:PageContent"
+        sling:resourceType="${appsFolderName}/components/structure/page">
+        <root
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="wcm/foundation/components/responsivegrid"
+            editable="{Boolean}true"/>
+        <cq:responsive jcr:primaryType="nt:unstructured">
+            <breakpoints jcr:primaryType="nt:unstructured">
+                <phone
+                    jcr:primaryType="nt:unstructured"
+                    title="Smaller Screen"
+                    width="{Long}650"/>
+                <tablet
+                    jcr:primaryType="nt:unstructured"
+                    title="Tablet"
+                    width="{Long}1200"/>
+            </breakpoints>
+        </cq:responsive>
+    </jcr:content>
+</jcr:root>

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/content/experience-fragments/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/content/experience-fragments/.content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:rep="internal"
+    cq:allowedTemplates="[/libs/cq/experience-fragments/components/experiencefragment/template,/libs/settings/screens/experience-fragments/templates/experience-fragment-template-screens,/conf/we-retail-screens/settings/wcm/templates/experience-fragment-screens-variation,/conf/we-retail/settings/wcm/templates/experience-fragment(.*)?,/conf/${confFolderName}/settings/wcm/templates/experience-fragment(.*)?]"
+    jcr:mixinTypes="[rep:AccessControllable]"
+    jcr:primaryType="sling:Folder"
+    jcr:title="Experience Fragments"/>

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/content/experience-fragments/__contentFolderName__/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/content/experience-fragments/__contentFolderName__/.content.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    cq:adobeTargetExportFormat="html"
+    jcr:primaryType="sling:OrderedFolder"
+    jcr:title="${siteName}">
+    <header/>
+    <footer/>
+</jcr:root>

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/content/experience-fragments/__contentFolderName__/footer/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/content/experience-fragments/__contentFolderName__/footer/.content.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        cq:lastModified="{Date}2019-05-14T11:42:32.289+05:30"
+        cq:lastModifiedBy="admin"
+        cq:tags="[]"
+        cq:template="/libs/cq/experience-fragments/components/experiencefragment/template"
+        jcr:description="${siteName} Footer Experience Fragment"
+        jcr:primaryType="cq:PageContent"
+        jcr:title="${siteName} Footer"
+        sling:resourceType="cq/experience-fragments/components/experiencefragment"/>
+    <master/>
+</jcr:root>

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/content/experience-fragments/__contentFolderName__/footer/master/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/content/experience-fragments/__contentFolderName__/footer/master/.content.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        cq:lastModified="{Date}2019-05-14T11:42:32.307+05:30"
+        cq:lastModifiedBy="admin"
+        cq:tags="[]"
+        cq:template="/conf/${confFolderName}/settings/wcm/templates/experience-fragment-web-variation"
+        cq:xfMasterVariation="{Boolean}true"
+        cq:xfVariantType="web"
+        jcr:description="${siteName} Footer Experience Fragment"
+        jcr:primaryType="cq:PageContent"
+        jcr:title="${siteName} Footer"
+        sling:resourceType="${appsFolderName}/components/structure/xfpage">
+        <root
+            jcr:lastModified="{Date}2016-11-22T17:31:48.669+02:00"
+            jcr:lastModifiedBy="admin"
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="wcm/foundation/components/responsivegrid"/>
+    </jcr:content>
+</jcr:root>

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/content/experience-fragments/__contentFolderName__/header/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/content/experience-fragments/__contentFolderName__/header/.content.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        cq:lastModified="{Date}2019-05-14T11:41:59.365+05:30"
+        cq:lastModifiedBy="admin"
+        cq:tags="[]"
+        cq:template="/libs/cq/experience-fragments/components/experiencefragment/template"
+        jcr:description="${siteName} Header Experience Fragment"
+        jcr:primaryType="cq:PageContent"
+        jcr:title="${siteName} Header"
+        sling:resourceType="cq/experience-fragments/components/experiencefragment"/>
+    <master/>
+</jcr:root>

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/content/experience-fragments/__contentFolderName__/header/master/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/content/experience-fragments/__contentFolderName__/header/master/.content.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        cq:lastModified="{Date}2019-05-14T11:41:59.388+05:30"
+        cq:lastModifiedBy="admin"
+        cq:tags="[]"
+        cq:template="/conf/${confFolderName}/settings/wcm/templates/experience-fragment-web-variation"
+        cq:xfMasterVariation="{Boolean}true"
+        cq:xfVariantType="web"
+        jcr:description="${siteName} Header Experience Fragment"
+        jcr:primaryType="cq:PageContent"
+        jcr:title="${siteName} Header"
+        sling:resourceType="${appsFolderName}/components/structure/xfpage">
+        <root
+            jcr:lastModified="{Date}2016-11-22T17:31:48.669+02:00"
+            jcr:lastModifiedBy="admin"
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="wcm/foundation/components/responsivegrid"/>
+    </jcr:content>
+</jcr:root>


### PR DESCRIPTION
2 experience fragments for header footer related to the custom project will also be generated during archetype execution and associated with the pages created using these templates(homepage/landing)

Add basic data layer object for analytics.

## Related Issue
https://github.com/adobe/aem-project-archetype/issues/174