### PR TITLE
enable config browser settings

### DIFF
--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/cloudconfigs/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/cloudconfigs/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"/>

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/dam/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/dam/.content.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Page">
-    <templates/>
-    <policies/>
-    <template-types/>
-    <segments/>
+    <cfm/>
 </jcr:root>

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/dam/cfm/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/dam/cfm/.content.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Page">
-    <templates/>
-    <policies/>
-    <template-types/>
-    <segments/>
+    <models/>
 </jcr:root>

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/dam/cfm/models/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/dam/cfm/models/.content.xml
@@ -1,8 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
-    jcr:primaryType="cq:Page">
-    <templates/>
-    <policies/>
-    <template-types/>
-    <segments/>
-</jcr:root>
+    jcr:primaryType="cq:Page"/>

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/segments/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/segments/.content.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        jcr:primaryType="cq:PageContent"
+        sling:resourceType="cq/contexthub/components/segments-listing-page"/>
+</jcr:root>


### PR DESCRIPTION
This will enable the below 3 configuration settings during archetype execution for generating mid market blueprint projects

Add ContextHub segments
Add Cloud Services
Add Content Fragment Models


 