### PR TITLE
Switch to default Import-Package header

### DIFF
--- a/src/main/archetype/core/pom.xml
+++ b/src/main/archetype/core/pom.xml
@@ -50,7 +50,6 @@ Bundle-Category: ${componentGroupName}
 Sling-Model-Packages: ${package}.core.models
 -snapshot: $${startbrace}tstamp;yyyyMMddHHmmssSSS${endbrace}
 Bundle-DocURL:
-Import-Package: javax.inject;version="0.0.0",javax.annotation;version="0.0.0",*
                                 ]]></bnd>
                         </configuration>
                     </execution>
@@ -128,14 +127,6 @@ Import-Package: javax.inject;version="0.0.0",javax.annotation;version="0.0.0",*
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.resource</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
         </dependency>
         <!-- Other Dependencies -->
         <dependency>

--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -564,17 +564,6 @@
                 <version>1.9.0</version>
                 <scope>provided</scope>
             </dependency>
-            <dependency>
-                <groupId>javax.inject</groupId>
-                <artifactId>javax.inject</artifactId>
-                <version>1</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.annotation</groupId>
-                <artifactId>javax.annotation-api</artifactId>
-                <version>1.3.2</version>
-                <scope>provided</scope>
-            </dependency>
             <!-- Logging Dependencies -->
             <dependency>
                 <groupId>org.slf4j</groupId>


### PR DESCRIPTION
- remove the specific Import-Package header so the default value is used
- remove unnecessary dependency of the javax.inject and javax.annotation artifacts

fixes #211