### PR TITLE
Changed 'js' to '.js' in resolve.extensions (ui.frontend -> webpack.commons.js)

### DIFF
--- a/src/main/archetype/ui.frontend/webpack.common.js
+++ b/src/main/archetype/ui.frontend/webpack.common.js
@@ -11,7 +11,7 @@ const SOURCE_ROOT = __dirname + '/src/main/webpack';
 
 module.exports = {
         resolve: {
-            extensions: ['js', '.ts'],
+            extensions: ['.js', '.ts'],
             plugins: [new TSConfigPathsPlugin({
                 configFile: "./tsconfig.json"
             })]


### PR DESCRIPTION
## Description

Node modules were not being properly resolved by Webpack because the file extension was 'js' instead of '.js' on line 15 of webpack.commons

## Related Issue

https://github.com/adobe/aem-project-archetype/issues/226

## Motivation and Context

Allows importing of entire modules vs. only importing their inner /dist js files

## How Has This Been Tested?

Built webpack with '.js' instead of 'js'

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.