### PR TITLE
include ConfigurationClassScannerPlugin to ease the use of CA-Config …

### DIFF
--- a/src/main/archetype/core/pom.xml
+++ b/src/main/archetype/core/pom.xml
@@ -50,10 +50,18 @@ Bundle-Category: ${componentGroupName}
 Sling-Model-Packages: ${package}.core.models
 -snapshot: $${startbrace}tstamp;yyyyMMddHHmmssSSS${endbrace}
 Bundle-DocURL:
+-plugin org.apache.sling.caconfig.bndplugin.ConfigurationClassScannerPlugin
                                 ]]></bnd>
                         </configuration>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.sling</groupId>
+                        <artifactId>org.apache.sling.caconfig.bnd-plugin</artifactId>
+                        <version>1.0.2</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>


### PR DESCRIPTION
Ease the handling of ContentAwareConfiguration by including the scanner into the standard build. See also https://issues.apache.org/jira/browse/SLING-8748 for details (current documentation does not work with this raw BND statements).