### PR TITLE
Specifying Maven Failsafe JUnit4 provider for integration tests

### DIFF
--- a/src/main/archetype/it.launcher/pom.xml
+++ b/src/main/archetype/it.launcher/pom.xml
@@ -240,6 +240,14 @@
                                 <sling.additional.bundle.6>org.apache.sling.testing.tools</sling.additional.bundle.6>
                             </systemPropertyVariables>
                         </configuration>
+                        <dependencies>
+                          <!-- Specify provider to process JUnit4 tests -->
+                          <dependency>
+                            <groupId>org.apache.maven.surefire</groupId>
+                            <artifactId>surefire-junit47</artifactId>
+                            <version>2.22.2</version>
+                          </dependency>
+                        </dependencies>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
## Description
Specified the use of a JUnit4 provider for Maven Failsafe Plugin integration tests in the `it.launcher` `pom.xml` file as per the [JUnit Provider Selection](https://maven.apache.org/surefire/maven-failsafe-plugin/examples/junit-platform.html) portion of the documentation.

## Related Issue
- Fixes adobe#243

## Motivation and Context
Running `mvn clean verify -PintegrationTests` now triggers integration tests in the `it.launcher` modules of the project to allow integration tests to run on an AEM server.

## How Has This Been Tested?
This change was tested by running `mvn clean verify -PintegrationTests` against an AEM 6.5 server and validating that the `it.launcher` module successfully ran its server-side sample test.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.