### PR TITLE
Update of client library inclusion fixes double minification

### DIFF
--- a/src/main/archetype/README.md
+++ b/src/main/archetype/README.md
@@ -56,7 +56,7 @@ The project comes with the auto-public repository configured. To setup the repos
 
     http://helpx.adobe.com/experience-manager/kb/SetUpTheAdobeMavenRepository.html
 
-## Frontend Build 
+## Frontend Build
 
 ### Features
 
@@ -90,8 +90,10 @@ The following npm scripts drive the frontend workflow:
 
 #### General
 
-* **Site** - `site.js`, `site.css` and a `resources/` folder for layout dependent images and fonts are created in a `clientlib-site` folder. 
-* **Dependencies** - `dependencies.js` and `dependencies.css` are created in a `clientlib-dependencies` folder.
+The ui.frontend module compiles the code under the `ui.frontend/src` folder and outputs the compiled CSS and JS, and any resources beneath a folder named `ui.frontend/dist`.
+
+* **Site** - `site.js`, `site.css` and a `resources/` folder for layout dependent images and fonts are created in a `dist/clientlib-site` folder.
+* **Dependencies** - `dependencies.js` and `dependencies.css` are created in a `dist/clientlib-dependencies` folder.
 
 #### JavaScript
 
@@ -114,6 +116,39 @@ called is removed.
 * **Cleaning** - explicit clean task for wiping out the generated CSS, JS and Map files on demand.
 * **Source Mapping** - development build only.
 
-### Notes
+#### Notes
 
 * Utilizes dev-only and prod-only webpack config files that share a common config file. This way the development and production settings can be tweaked independently.
+
+#### Client Library Generation
+
+The second part of the ui.frontend module build process leverages the [aem-clientlib-generator](https://www.npmjs.com/package/aem-clientlib-generator) plugin to move the compiled CSS, JS and any resources into the `ui.apps` module. The aem-clientlib-generator configuration is defined in `clientlib.config.js`. The following client libraries are generated:
+
+* **clientlib-site** - `ui.apps/src/main/content/jcr_root/apps/<app>/clientlibs/clientlib-site`
+* **clientlib-dependencies** - `ui.apps/src/main/content/jcr_root/apps/<app>/clientlibs/clientlib-dependencies`
+
+#### Page Inclusion
+
+`clientlib-site` and `clientlib-dependencies` categories are included on pages via the Page Policy configuration as part of the default template. To view the policy, edit the **Content Page Template**  > **Page Information** > **Page Policy**. 
+
+The final inclusion of client libraries on the sites page is as follows:
+
+```html
+
+<HTML>
+    <head>
+        <link rel="stylesheet" href="clientlib-base.css" type="text/css">
+        <script type="text/javascript" src="clientlib-dependencies.js"></script>
+        <link rel="stylesheet" href="clientlib-dependencies.css" type="text/css">
+        <link rel="stylesheet" href="clientlib-site.css" type="text/css">
+    </head>
+    <body>
+        ....
+        <script type="text/javascript" src="clientlib-site.js"></script>
+        <script type="text/javascript" src="clientlib-base.js"></script>
+    </body>
+</HTML>
+```
+
+The above inclusion can of course be modified by updating the Page Policy and/or modifying the categories and embed properties of respective clientlibraries.
+

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/clientlibs/clientlib-base/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/clientlibs/clientlib-base/.content.xml
@@ -3,4 +3,4 @@
     jcr:primaryType="cq:ClientLibraryFolder"
     allowProxy="{Boolean}true"
     categories="[${cssId}.base]"
-    embed="[core.wcm.components.accordion.v1,core.wcm.components.tabs.v1,core.wcm.components.carousel.v1,core.wcm.components.image.v2,core.wcm.components.breadcrumb.v2,core.wcm.components.search.v1,core.wcm.components.form.text.v2,${cssId}.grid,${cssId}.dependencies,${cssId}.site]"/>
+    embed="[core.wcm.components.accordion.v1,core.wcm.components.tabs.v1,core.wcm.components.carousel.v1,core.wcm.components.image.v2,core.wcm.components.breadcrumb.v2,core.wcm.components.search.v1,core.wcm.components.form.text.v2,${cssId}.grid]"/>

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/policies/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/policies/.content.xml
@@ -46,6 +46,18 @@
                     </form-container>
                 </container>
             </form>
+            <structure jcr:primaryType="nt:unstructured">
+                 <page jcr:primaryType="nt:unstructured">
+                    <policy_content_page
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="${siteName} Page Policy"
+                        sling:resourceType="wcm/core/components/policy/policy"
+                        clientlibs="[${cssId}.dependencies,${cssId}.site]"
+                        clientlibsJsHead="${cssId}.dependencies">
+                        <jcr:content jcr:primaryType="nt:unstructured"/>
+                    </policy_content_page>
+                 </page>
+            </structure>
         </components>
     </${appsFolderName}>
 </jcr:root>

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/template-types/empty-page/policies/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/template-types/empty-page/policies/.content.xml
@@ -3,7 +3,8 @@
     jcr:primaryType="cq:Page">
     <jcr:content
         jcr:primaryType="nt:unstructured"
-        sling:resourceType="wcm/core/components/policies/mappings">
+        sling:resourceType="wcm/core/components/policies/mappings"
+        cq:policy="${appsFolderName}/components/structure/page/policy_content_page">
         <root
             cq:policy="wcm/foundation/components/responsivegrid/content-default"
             jcr:primaryType="nt:unstructured"

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/content-page/policies/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/content-page/policies/.content.xml
@@ -3,7 +3,8 @@
     jcr:primaryType="cq:Page">
     <jcr:content
         jcr:primaryType="nt:unstructured"
-        sling:resourceType="wcm/core/components/policies/mappings">
+        sling:resourceType="wcm/core/components/policies/mappings"
+        cq:policy="${appsFolderName}/components/structure/page/policy_content_page">
         <root
             cq:policy="wcm/foundation/components/responsivegrid/content-default"
             jcr:primaryType="nt:unstructured"


### PR DESCRIPTION
## Description

Changes the way `clientlib-site` and `clientlib-dependencies` are included as part of the project archetype. Instead of embedding these client libraries as part of `clientlib-base` these would now be included separately and configured via the **Page Template** > **Page Policy**. 

In addition to addressing #245, this also provides more flexibility for how client libraries are included since they can now be configured on a per-template basis.

## Motivation and Context

By separating `clientlib-site` and `clientlib-dependencies` from being embedded as part of `clientlib-base` it is now possible to minify Core Components CSS/JS, Responsive Grid CSS and any other client libraries that live in AEM while allowing client libraries generated by the ui.frontend module to be minified by the ui.frontend module (instead of by AEM). 

See issue #245 for more details

## How Has This Been Tested?

Tested using the generated project as part of the archetype.

## Screenshots (if appropriate):

`clientlib-site` and `clientlib-dependencies` are now included via the **Page Template** > **Page Policy**:

![image](https://user-images.githubusercontent.com/8974514/66244643-478b5880-e6be-11e9-8689-84fd244bae37.png)

The final inclusion of client libraries on the sites page is as follows:

```html

<HTML>
    <head>
        <link rel="stylesheet" href="clientlib-base.css" type="text/css">
        <script type="text/javascript" src="clientlib-dependencies.js"></script>
        <link rel="stylesheet" href="clientlib-dependencies.css" type="text/css">
        <link rel="stylesheet" href="clientlib-site.css" type="text/css">
    </head>
    <body>
        ....
        <script type="text/javascript" src="clientlib-site.js"></script>
        <script type="text/javascript" src="clientlib-base.js"></script>
    </body>
</HTML>
```

## Types of changes

The archetype, of course, is just a starting point, implementations modify the way client libraries are included based on specific needs.

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.