### PR TITLE
Static Webpack Dev Server

### DIFF
--- a/src/main/archetype/README.md
+++ b/src/main/archetype/README.md
@@ -11,6 +11,7 @@ The main parts of the template are:
 * ui.content: contains sample content using the components from the ui.apps
 * ui.tests: Java bundle containing JUnit tests that are executed server-side. This bundle is not to be deployed onto production.
 * ui.launcher: contains glue code that deploys the ui.tests bundle (and dependent bundles) to the server and triggers the remote JUnit execution
+* ui.frontend: an optional dedicated front-end build mechanism based on Webpack
 
 ## How to build
 
@@ -55,100 +56,3 @@ There are three levels of testing contained in the project:
 The project comes with the auto-public repository configured. To setup the repository in your Maven settings, refer to:
 
     http://helpx.adobe.com/experience-manager/kb/SetUpTheAdobeMavenRepository.html
-
-## Frontend Build
-
-### Features
-
-* Full TypeScript, ES6 and ES5 support (with applicable Webpack wrappers).
-* TypeScript and JavaScript linting (using a TSLint ruleset – to be refined).
-* ES5 output, for legacy browser support.
-* Globbing
-    * No need to add imports anywhere.
-    * All JS and CSS files can now be added to each component (best practice is under /clientlib/js or /clientlib/(s)css)
-    * No .content.xml or js.txt/css.txt files needed as everything is run through Webpack
-    * The globber pulls in all JS files under the /component/ folder. Webpack allows CSS/SCSS files to be chained in via JS files. They are pulled in through the two entry points, sites.js and vendors.js.
-    * The only files consumed by AEM are the output files site.js and site.css, the resources folder in /clientlib-site as well as dependencies.js and dependencies.css in /clientlib-dependencies
-* Chunks
-    * Main (site js/css)
-    * Vendors (dependencies js/css)
-* Full Sass/Scss support (Sass is compiled to CSS via Webpack).
-
-### Installation
-
-1. Install [NodeJS](https://nodejs.org/en/download/) (v10+), globally. This will also install `npm`.
-2. Navigate to `ui.frontend` in your project and run `npm install`. (You must have run the archetype with `-DoptionIncludeFrontendModule=y` to populate the ui.frontend folder) 
-
-### Usage
-
-The following npm scripts drive the frontend workflow:
-
-* `npm run dev` - full build with JS optimization disabled (tree shaking, etc) and source maps enabled and CSS optimization disabled.
-* `npm run prod` - full build with JS optimization enabled (tree shaking, etc), source maps disabled and CSS optimization enabled.
-
-### Output
-
-#### General
-
-The ui.frontend module compiles the code under the `ui.frontend/src` folder and outputs the compiled CSS and JS, and any resources beneath a folder named `ui.frontend/dist`.
-
-* **Site** - `site.js`, `site.css` and a `resources/` folder for layout dependent images and fonts are created in a `dist/clientlib-site` folder.
-* **Dependencies** - `dependencies.js` and `dependencies.css` are created in a `dist/clientlib-dependencies` folder.
-
-#### JavaScript
-
-* **Optimization** - for production builds, all JS that is not being used or
-called is removed.
-
-#### CSS
-
-* **Autoprefixing** - all CSS is run through a prefixer and any properties that require prefixing will automatically have those added in the CSS.
-* **Optimization** - at post, all CSS is run through an optimizer (cssnano) which normalizes it according to the following default rules:
-    * Reduces CSS calc expression wherever possible, ensuring both browser compatibility and compression.
-    * Converts between equivalent length, time and angle values. Note that by default, length values are not converted.
-    * Removes comments in and around rules, selectors & declarations.
-    * Removes duplicated rules, at-rules and declarations. Note that this only works for exact duplicates.
-    * Removes empty rules, media queries and rules with empty selectors, as they do not affect the output.
-    * Merges adjacent rules by selectors and overlapping property/value pairs.
-    * Ensures that only a single `@charset` is present in the CSS file and moves it to the top of the document.
-    * Replaces the CSS initial keyword with the actual value, when the resulting output is smaller.
-    * Compresses inline SVG definitions with SVGO.
-* **Cleaning** - explicit clean task for wiping out the generated CSS, JS and Map files on demand.
-* **Source Mapping** - development build only.
-
-#### Notes
-
-* Utilizes dev-only and prod-only webpack config files that share a common config file. This way the development and production settings can be tweaked independently.
-
-#### Client Library Generation
-
-The second part of the ui.frontend module build process leverages the [aem-clientlib-generator](https://www.npmjs.com/package/aem-clientlib-generator) plugin to move the compiled CSS, JS and any resources into the `ui.apps` module. The aem-clientlib-generator configuration is defined in `clientlib.config.js`. The following client libraries are generated:
-
-* **clientlib-site** - `ui.apps/src/main/content/jcr_root/apps/<app>/clientlibs/clientlib-site`
-* **clientlib-dependencies** - `ui.apps/src/main/content/jcr_root/apps/<app>/clientlibs/clientlib-dependencies`
-
-#### Page Inclusion
-
-`clientlib-site` and `clientlib-dependencies` categories are included on pages via the Page Policy configuration as part of the default template. To view the policy, edit the **Content Page Template**  > **Page Information** > **Page Policy**. 
-
-The final inclusion of client libraries on the sites page is as follows:
-
-```html
-
-<HTML>
-    <head>
-        <link rel="stylesheet" href="clientlib-base.css" type="text/css">
-        <script type="text/javascript" src="clientlib-dependencies.js"></script>
-        <link rel="stylesheet" href="clientlib-dependencies.css" type="text/css">
-        <link rel="stylesheet" href="clientlib-site.css" type="text/css">
-    </head>
-    <body>
-        ....
-        <script type="text/javascript" src="clientlib-site.js"></script>
-        <script type="text/javascript" src="clientlib-base.js"></script>
-    </body>
-</HTML>
-```
-
-The above inclusion can of course be modified by updating the Page Policy and/or modifying the categories and embed properties of respective clientlibraries.
-

--- a/src/main/archetype/ui.frontend/README.md
+++ b/src/main/archetype/ui.frontend/README.md
@@ -1,0 +1,111 @@
+#set($hash = '#')${hash} Frontend Build
+
+${hash}${hash} Features
+
+* Full TypeScript, ES6 and ES5 support (with applicable Webpack wrappers).
+* TypeScript and JavaScript linting (using a TSLint ruleset – to be refined).
+* ES5 output, for legacy browser support.
+* Globbing
+    * No need to add imports anywhere.
+    * All JS and CSS files can now be added to each component (best practice is under /clientlib/js or /clientlib/(s)css)
+    * No .content.xml or js.txt/css.txt files needed as everything is run through Webpack
+    * The globber pulls in all JS files under the /component/ folder. Webpack allows CSS/SCSS files to be chained in via JS files. They are pulled in through the two entry points, sites.js and vendors.js.
+    * The only files consumed by AEM are the output files site.js and site.css, the resources folder in /clientlib-site as well as dependencies.js and dependencies.css in /clientlib-dependencies
+* Chunks
+    * Main (site js/css)
+    * Vendors (dependencies js/css)
+* Full Sass/Scss support (Sass is compiled to CSS via Webpack).
+* Static webpack development server with built in proxy to a local instance of AEM
+
+${hash}${hash} Installation
+
+1. Install [NodeJS](https://nodejs.org/en/download/) (v10+), globally. This will also install `npm`.
+2. Navigate to `ui.frontend` in your project and run `npm install`. (You must have run the archetype with `-DoptionIncludeFrontendModule=y` to populate the ui.frontend folder)
+
+${hash}${hash} Usage
+
+The following npm scripts drive the frontend workflow:
+
+* `npm run dev` - Full build of client libraries with JS optimization disabled (tree shaking, etc) and source maps enabled and CSS optimization disabled.
+* `npm run prod` - Full build of client libraries build with JS optimization enabled (tree shaking, etc), source maps disabled and CSS optimization enabled.
+* `npm run start` - Starts a static webpack development server for local development with minimal dependencies on AEM.
+
+${hash}${hash}${hash} General
+
+The ui.frontend module compiles the code under the `ui.frontend/src` folder and outputs the compiled CSS and JS, and any resources beneath a folder named `ui.frontend/dist`.
+
+* **Site** - `site.js`, `site.css` and a `resources/` folder for layout dependent images and fonts are created in a `dist/clientlib-site` folder.
+* **Dependencies** - `dependencies.js` and `dependencies.css` are created in a `dist/clientlib-dependencies` folder.
+
+${hash}${hash}${hash} JavaScript
+
+* **Optimization** - for production builds, all JS that is not being used or
+called is removed.
+
+${hash}${hash}${hash} CSS
+
+* **Autoprefixing** - all CSS is run through a prefixer and any properties that require prefixing will automatically have those added in the CSS.
+* **Optimization** - at post, all CSS is run through an optimizer (cssnano) which normalizes it according to the following default rules:
+    * Reduces CSS calc expression wherever possible, ensuring both browser compatibility and compression.
+    * Converts between equivalent length, time and angle values. Note that by default, length values are not converted.
+    * Removes comments in and around rules, selectors & declarations.
+    * Removes duplicated rules, at-rules and declarations. Note that this only works for exact duplicates.
+    * Removes empty rules, media queries and rules with empty selectors, as they do not affect the output.
+    * Merges adjacent rules by selectors and overlapping property/value pairs.
+    * Ensures that only a single `@charset` is present in the CSS file and moves it to the top of the document.
+    * Replaces the CSS initial keyword with the actual value, when the resulting output is smaller.
+    * Compresses inline SVG definitions with SVGO.
+* **Cleaning** - explicit clean task for wiping out the generated CSS, JS and Map files on demand.
+* **Source Mapping** - development build only.
+
+${hash}${hash}${hash}${hash} Notes
+
+* Utilizes dev-only and prod-only webpack config files that share a common config file. This way the development and production settings can be tweaked independently.
+
+${hash}${hash}${hash} Client Library Generation
+
+The second part of the ui.frontend module build process leverages the [aem-clientlib-generator](https://www.npmjs.com/package/aem-clientlib-generator) plugin to move the compiled CSS, JS and any resources into the `ui.apps` module. The aem-clientlib-generator configuration is defined in `clientlib.config.js`. The following client libraries are generated:
+
+* **clientlib-site** - `ui.apps/src/main/content/jcr_root/apps/<app>/clientlibs/clientlib-site`
+* **clientlib-dependencies** - `ui.apps/src/main/content/jcr_root/apps/<app>/clientlibs/clientlib-dependencies`
+
+${hash}${hash}${hash}  Page Inclusion
+
+`clientlib-site` and `clientlib-dependencies` categories are included on pages via the Page Policy configuration as part of the default template. To view the policy, edit the **Content Page Template**  > **Page Information** > **Page Policy**.
+
+The final inclusion of client libraries on the sites page is as follows:
+
+```html
+
+<HTML>
+    <head>
+        <link rel="stylesheet" href="clientlib-base.css" type="text/css">
+        <script type="text/javascript" src="clientlib-dependencies.js"></script>
+        <link rel="stylesheet" href="clientlib-dependencies.css" type="text/css">
+        <link rel="stylesheet" href="clientlib-site.css" type="text/css">
+    </head>
+    <body>
+        ....
+        <script type="text/javascript" src="clientlib-site.js"></script>
+        <script type="text/javascript" src="clientlib-base.js"></script>
+    </body>
+</HTML>
+```
+
+The above inclusion can of course be modified by updating the Page Policy and/or modifying the categories and embed properties of respective client libraries.
+
+${hash}${hash}${hash} Static Webpack Development Server
+
+Included in the ui.frontend module is a [webpack-dev-server](https://github.com/webpack/webpack-dev-server) that provides live reloading for rapid front-end development outside of AEM. The setup leverages the [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin) to automatically inject CSS and JS compiled from the ui.frontend module into a static HTML template.
+
+${hash}${hash}${hash}${hash} Important files
+
+* `ui.frontend/webpack.dev.js` - This contains the configuration for the webpack-dev-serve and points to the html template to use. It also contains a proxy configuration to an AEM instance running on `localhost:4502`.
+* `ui.frontend/src/main/webpack/static/index.html` - This is the static HTML that the server will run against. This allows a developer to make CSS/JS changes and see them immediately reflected in the markup. It is assumed that the markup placed in this file accurately reflects generated markup by AEM components. Note* that markup in this file does **not** get automatically synced with AEM component markup. This file also contains references to client libraries stored in AEM, like Core Component CSS and Responsive Grid CSS. The webpack development server is set up to proxy these CSS/JS includes from a local running AEM instance based on the configuration found in `ui.frontend/webpack.dev.js`.
+
+${hash}${hash}${hash}${hash} Using
+
+1. From within the root of the project run the command `mvn -PautoInstallSinglePackage clean install` to install the entire project to an AEM instance running at `localhost:4502`
+2. Navigate inside the `ui.frontend` folder.
+3. Run the following command `npm run start` to start the webpack dev server. Once started it should open a browser (localhost:8080 or the next available port).
+4. You can now modify CSS, JS, SCSS, and TS files and see the changes immediately reflected in the webpack dev server.

--- a/src/main/archetype/ui.frontend/package.json
+++ b/src/main/archetype/ui.frontend/package.json
@@ -11,7 +11,8 @@
     "license": "SEE LICENSE IN LICENSE.txt",
     "scripts": {
       "dev": "webpack -d --env dev --config ./webpack.dev.js && clientlib --verbose",
-      "prod": "webpack -p --config ./webpack.prod.js && clientlib --verbose"
+      "prod": "webpack -p --config ./webpack.prod.js && clientlib --verbose",
+      "start": "webpack-dev-server --open --config ./webpack.dev.js"
     },
     "devDependencies": {
       "@babel/core": "^7.0.0",
@@ -25,6 +26,7 @@
       "copy-webpack-plugin": "^5.0.4",
       "css-loader": "^3.0.0",
       "cssnano": "^4.1.10",
+      "html-webpack-plugin": "^3.2.0",
       "mini-css-extract-plugin": "^0.4.4",
       "node-sass": "^4.11.0",
       "optimize-css-assets-webpack-plugin": "^5.0.1",
@@ -42,6 +44,7 @@
       "typescript": "^3.3.3333",
       "webpack": "^4.27.1",
       "webpack-cli": "^3.1.2",
+      "webpack-dev-server": "^3.9.0",
       "webpack-import-glob-loader": "^1.6.3",
       "webpack-merge": "^4.2.1"
     },

--- a/src/main/archetype/ui.frontend/src/main/webpack/static/index.html
+++ b/src/main/archetype/ui.frontend/src/main/webpack/static/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE HTML>
+<html lang="en">
+    <head>
+    <meta charset="UTF-8"/>
+    <title>Static Frontend File</title>
+    <meta name="template" content="content-page-template"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <!-- proxied from a running instance of AEM -->
+    <link rel="stylesheet" href="/etc.clientlibs/${appsFolderName}/clientlibs/clientlib-base.css" type="text/css"> 
+</head>
+    <body class="page basicpage">      
+        <!-- Root Layout Container -->    
+        <div class="root responsivegrid">
+            <div class="aem-Grid aem-Grid--12 aem-Grid--default--12 ">
+                <!-- Editable Layout Container -->
+                <div class="responsivegrid aem-GridColumn aem-GridColumn--default--12">
+                    <div class="aem-Grid aem-Grid--12 aem-Grid--default--12 ">
+                        <!-- Title Component-->
+                        <div class="title aem-GridColumn aem-GridColumn--default--12">
+                            <div class="cmp-title">
+                                <h1 class="cmp-title__text">My Static Template</h1>
+                            </div>   
+                        </div><!-- end Title Component -->
+
+                        <!-- Text Component 1 -->
+                        <div class="text aem-GridColumn--offset--tablet--0 aem-GridColumn--default--none aem-GridColumn--phone--none aem-GridColumn--phone--12 aem-GridColumn--tablet--none aem-GridColumn--default--9 aem-GridColumn aem-GridColumn--tablet--6 aem-GridColumn--offset--phone--0 aem-GridColumn--offset--default--0">
+                            <div class="cmp-text">
+                                <h2><b>Column 1</b></h2>
+                                <p><b>Bold</b> can be used to emphasize a word or phrase, as can <u>underline</u> and <i>italics</i>. <sup>Superscript</sup> and <sub>subscript</sub> are useful for mathematical (E = mc<sup>2</sup>) or scientific (h<sub>2</sub>O) expressions. Paragraph styles can provide alternative renderings, such as quote sections:</p>
+                                <p></p>
+                                <blockquote>“Be yourself; everyone else is already taken.”</blockquote>
+                                <blockquote>- Oscar Wilde</blockquote>
+                                <blockquote> </blockquote>
+                                <h3>Responsive Widths</h4>
+                                <ul>
+                                <li>default= 9</li>
+                                <li>tablet=6</li>
+                                <li>phone=12</li>
+                                </ul>
+                                <p> </p>
+                            </div>
+                        </div><!-- End Text Component 1-->
+
+                        <!-- Text Component 2 -->
+                        <div class="text aem-GridColumn--offset--tablet--0 aem-GridColumn--default--none aem-GridColumn--phone--none aem-GridColumn--phone--12 aem-GridColumn--tablet--none aem-GridColumn aem-GridColumn--tablet--6 aem-GridColumn--offset--phone--0 aem-GridColumn--default--3 aem-GridColumn--offset--default--0">
+                            <div class="cmp-text">
+                                <h2><b>Column 2</b></h2>
+                                <p><b>Bold</b> can be used to emphasize a word or phrase, as can <u>underline</u> and <i>italics</i>. <sup>Superscript</sup> and <sub>subscript</sub> are useful for mathematical (E = mc<sup>2</sup>) or scientific (h<sub>2</sub>O) expressions. Paragraph styles can provide alternative renderings, such as quote sections:</p>
+                                <p> </p>
+                                <blockquote>“Be yourself; everyone else is already taken.”</blockquote>
+                                <blockquote>- Oscar Wilde</blockquote>
+                                <blockquote> </blockquote>
+                                <h3>Responsive Widths</h3>
+                                <ul>
+                                <li>default=3</li>
+                                <li>tablet=6</li>
+                                <li>phone=12</li>
+                                </ul>
+                                <p> </p>
+                            </div>
+                        </div><!-- end Text Component 2-->
+                    </div>
+                 </div><!-- end Editable Layout Container -->
+            </div>
+        </div><!-- end Root Layout Container -->   
+
+        <!-- proxied from a running instance of AEM -->
+        <script type="text/javascript" src="/etc.clientlibs/${appsFolderName}/clientlibs/clientlib-base.js"></script>        
+    </body>
+</html>

--- a/src/main/archetype/ui.frontend/webpack.dev.js
+++ b/src/main/archetype/ui.frontend/webpack.dev.js
@@ -1,8 +1,24 @@
 const merge = require('webpack-merge');
 const common = require('./webpack.common.js');
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+const SOURCE_ROOT = __dirname + '/src/main/webpack';
 
 module.exports = merge(common, {
    mode: 'development',
    devtool: 'inline-source-map',
-   performance: {hints: "warning"}
+   performance: {hints: "warning"},
+   plugins: [
+      new HtmlWebpackPlugin({
+         template: path.resolve(__dirname, SOURCE_ROOT + '/static/index.html')
+      })
+   ],
+   devServer: {
+      inline: true,
+      proxy: [{
+         context: ['/content', '/etc.clientlibs'],
+         target: 'http://localhost:4502',
+      }]
+   }
 });

--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -215,6 +215,7 @@
                         <include>.gitignore</include>
                         <include>clientlib.config.js</include>
                         <include>package.json</include>
+                        <include>README.md</include>
                         <include>tsconfig.json</include>
                         <include>tslint.json</include>
                         <include>webpack.common.js</include>
@@ -222,7 +223,7 @@
                         <include>webpack.prod.js</include>
                     </includes>
                 </fileSet>
-                <fileSet filtered="false" packaged="false"
+                <fileSet filtered="true" packaged="false"
                          encoding="UTF-8">
                     <directory>src/main/webpack</directory>
                     <includes>


### PR DESCRIPTION
## Description

Provides an initial implementation for issue #246 

Included in the ui.frontend module is a [webpack-dev-server](https://github.com/webpack/webpack-dev-server) that provides live reloading for rapid front-end development outside of AEM. The setup leverages the [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin) to automatically inject CSS and JS compiled from the ui.frontend module into a static HTML template.

**Important files**

* `ui.frontend/webpack.dev.js` - This contains the configuration for the webpack-dev-serve and points to the html template to use. It also contains a proxy configuration to an AEM instance running on `localhost:4502`.
* `ui.frontend/src/main/webpack/static/index.html` - This is the static HTML that the server will run against. This allows a developer to make CSS/JS changes and see them immediately reflected in the markup. It is assumed that the markup placed in this file accurately reflects generated markup by AEM components. Note* that markup in this file does **not** get automatically synced with AEM component markup. This file also contains references to client libraries stored in AEM, like Core Component CSS and Responsive Grid CSS. The webpack development server is set up to proxy these CSS/JS includes from a local running AEM instance based on the configuration found in `ui.frontend/webpack.dev.js`.

**Using**

1. From within the root of the project run the command `mvn -PautoInstallSinglePackage clean install` to install the entire project to an AEM instance running at `localhost:4502`
2. Navigate inside the `ui.frontend` folder.
3. Run the following command `npm run start` to start the webpack dev server. Once started it should open a browser (localhost:8080 or the next available port).
4. You can now modify CSS, JS, SCSS, and TS files and see the changes immediately reflected in the webpack dev server.

## Motivation and Context

This allows a front end developer to develop CSS/JS against static markup, allowing the FED to be further de-coupled from AEM. The webpack dev server allows for live reloading of the browser for rapid development.

## How Has This Been Tested?

Tested with local archetype setup.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (I updated the README.md)
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.