### PR TITLE
[Frontend] ui.frontend needs to be build before ui.apps

### DIFF
--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -34,7 +34,9 @@
     <modules>
         <module>all</module>
         <module>core</module>
+#if ( $optionIncludeFrontendModule == "y" )
         <module>ui.frontend</module>
+#end
         <module>ui.apps</module>
         <module>ui.content</module>
         <module>it.tests</module>

--- a/src/main/archetype/repository-structure/pom.xml
+++ b/src/main/archetype/repository-structure/pom.xml
@@ -17,7 +17,7 @@
     <!-- ====================================================================== -->
     <artifactId>${artifactId}</artifactId>
     <packaging>content-package</packaging>
-    <name>${artifactName} - Adobe Experience Manager Repository Structure Package</name>
+    <name>${artifactName} - Repository Structure Package</name>
     <description>
         Empty package that defines the structure of the Adobe Experience Manager repository the Code packages in this project deploy into.
         Any roots in the Code packages of this project should have their parent enumerated in the Filters list below.

--- a/src/main/archetype/ui.apps/pom.xml
+++ b/src/main/archetype/ui.apps/pom.xml
@@ -118,7 +118,7 @@
             <groupId>${groupId}</groupId>
             <artifactId>${rootArtifactId}.ui.frontend</artifactId>
             <version>${version}</version>
-            <type>pom</type>
+            <type>zip</type>
         </dependency>
 #end
 

--- a/src/main/archetype/ui.apps/pom.xml
+++ b/src/main/archetype/ui.apps/pom.xml
@@ -113,6 +113,15 @@
             <version>${version}</version>
         </dependency>
 
+#if ( $optionIncludeFrontendModule == "y" )
+        <dependency>
+            <groupId>${groupId}</groupId>
+            <artifactId>${rootArtifactId}.ui.frontend</artifactId>
+            <version>${version}</version>
+            <type>pom</type>
+        </dependency>
+#end
+
         <dependency>
             <groupId>com.adobe.cq</groupId>
             <artifactId>core.wcm.components.core</artifactId>

--- a/src/main/archetype/ui.frontend/assembly.xml
+++ b/src/main/archetype/ui.frontend/assembly.xml
@@ -1,0 +1,18 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+    <id>distribution</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>${basedir}/dist</directory>
+            <includes>
+                <include>**/*</include>
+            </includes>
+            <outputDirectory></outputDirectory>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/src/main/archetype/ui.frontend/pom.xml
+++ b/src/main/archetype/ui.frontend/pom.xml
@@ -58,6 +58,25 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>assembly.xml</descriptor>
+                            </descriptors>
+                            <appendAssemblyId>false</appendAssemblyId>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
- added ui.frontend as a dependency to the ui.apps module
- exclude ui.frontend module in root pom if frontend module is skipped

fixes #267 