### PR TITLE
javax.annotation,version -- Cannot be resolved

### DIFF
--- a/src/main/archetype/core/pom.xml
+++ b/src/main/archetype/core/pom.xml
@@ -44,6 +44,7 @@
                         <configuration>
                             <bnd><![CDATA[
 Bundle-Category: ${componentGroupName}
+Import-Package: javax.annotation;version=0.0.0,*
 -exportcontents: $${startbrace}packages;VERSIONED${endbrace}
 Sling-Model-Packages: ${package}.core.models
 -snapshot: $${startbrace}tstamp;yyyyMMddHHmmssSSS${endbrace}
@@ -146,6 +147,10 @@ Bundle-DocURL:
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.adobe.aem</groupId>

--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -633,6 +633,13 @@
                 <version>2.1</version>
                 <scope>provided</scope>
             </dependency>
+
+            <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>1.3.2</version>
+                <scope>provided</scope>
+            </dependency>
             <!-- JCR -->
             <dependency>
                 <groupId>javax.jcr</groupId>


### PR DESCRIPTION
- add javax.annotation as provided dependency and set minimum version in bundle plugin

fixes #229