### PR TITLE
Allow all clientlibs to be tracked by git by default

### DIFF
--- a/src/main/archetype/ui.apps/.gitignore
+++ b/src/main/archetype/ui.apps/.gitignore
@@ -1,5 +1,0 @@
-# Created by https://www.gitignore.io/api/eclipse,java,maven
-
-### FE generated files ###
-src/main/content/jcr_root/apps/${appsFolderName}/clientlibs/clientlib-site
-src/main/content/jcr_root/apps/${appsFolderName}/clientlibs/clientlib-dependencies


### PR DESCRIPTION
## Description

The .gitignore file was ignoring folders that could have source code which should be tracked

## Related Issue

https://github.com/adobe/aem-project-archetype/issues/278

## Motivation and Context

Prevents developers from losing code which should be tracked

## How Has This Been Tested?

Built the archetype from master branch of source. Created a new project from the archetype. Made updates and rebuilt the archetype. Created a new project and diff'ed to validate that the only change was the removed .gitignore file

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.