### PR TITLE
Ignore ClientLibs generated by frontend module

### DIFF
--- a/src/main/archetype/ui.apps/.gitignore
+++ b/src/main/archetype/ui.apps/.gitignore
@@ -1,0 +1,4 @@
+#if ( $optionIncludeFrontendModule == "y" )
+src/main/content/jcr_root/apps/${appsFolderName}/clientlibs/clientlib-site
+src/main/content/jcr_root/apps/${appsFolderName}/clientlibs/clientlib-dependencies
+#end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds back the content of the `.gitignore` file which was removed in https://github.com/adobe/aem-project-archetype/pull/279, but only if a frontend module is used (which means that the content of the ClientLibs is not provided by the user but generated by Webpack).

## Related Issues

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/adobe/aem-project-archetype/issues/278, https://github.com/adobe/aem-project-archetype/pull/279

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

See discussion in https://github.com/adobe/aem-project-archetype/pull/279.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.