### PR TITLE
Use org.apache.sling.bnd.models.ModelsScannerPlugin in core project

### DIFF
--- a/src/main/archetype/core/pom.xml
+++ b/src/main/archetype/core/pom.xml
@@ -46,10 +46,10 @@
 Bundle-Category: ${componentGroupName}
 Import-Package: javax.annotation;version=0.0.0,*
 -exportcontents: $${startbrace}packages;VERSIONED${endbrace}
-Sling-Model-Packages: ${package}.core.models
 -snapshot: $${startbrace}tstamp;yyyyMMddHHmmssSSS${endbrace}
 Bundle-DocURL:
 -plugin org.apache.sling.caconfig.bndplugin.ConfigurationClassScannerPlugin
+-plugin org.apache.sling.bnd.models.ModelsScannerPlugin
                                 ]]></bnd>
                         </configuration>
                     </execution>
@@ -59,6 +59,11 @@ Bundle-DocURL:
                         <groupId>org.apache.sling</groupId>
                         <artifactId>org.apache.sling.caconfig.bnd-plugin</artifactId>
                         <version>1.0.2</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.sling</groupId>
+                        <artifactId>org.apache.sling.bnd.models</artifactId>
+                        <version>1.0.0</version>
                     </dependency>
                 </dependencies>
             </plugin>


### PR DESCRIPTION
- add dependency to org.apache.sling.bnd.models
- add plugin configuration for ModelsScannerPlugin

fixes #297