### PR TITLE
'all' package gets deleted at end of build

### DIFF
--- a/src/main/archetype/all/pom.xml
+++ b/src/main/archetype/all/pom.xml
@@ -117,7 +117,7 @@
                 <executions>
                     <execution>
                         <id>auto-clean</id>
-                        <phase>install</phase>
+                        <phase>initialize</phase>
                         <goals>
                             <goal>clean</goal>
                         </goals>


### PR DESCRIPTION
- bind clean goal to initialize instead install phase

fixes #289