### PR TITLE
Bug Fix: Prod Webpack config now minifies JS and CSS

### DIFF
--- a/src/main/archetype/ui.frontend.general/webpack.prod.js
+++ b/src/main/archetype/ui.frontend.general/webpack.prod.js
@@ -6,6 +6,7 @@ const common                  = require('./webpack.common.js');
 module.exports = merge(common, {
     mode: 'production',
     optimization: {
+        minimize: true,
         minimizer: [
             new TerserPlugin(),
             new OptimizeCSSAssetsPlugin({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Webpack Prod config now minifies JS and CSS.

<!--- Describe your changes in detail -->

## Motivation and Context

This fixes a bug where no JS or CSS was getting minified when run through the production configuration.

## How Has This Been Tested?

Yes

## Screenshots (if appropriate):

## Types of changes

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.