### PR TITLE
Incorrect property name in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ optionAemVersion            |  6.5.0  | Target AEM version
 language_country            |   en_us | language / country code to create the content structure from (e.g. en_us)
 optionIncludeExamples       |    y    | Include a Component Library example site
 optionIncludeErrorHandler   |    n    | Include a custom 404 response page
-optionFrontendModule        |   none  | Include a dedicated frontend module (one of `none`, `general`, `angular`, `react`)
+optionIncludeFrontendModule |   none  | Include a dedicated frontend module (one of `none`, `general`, `angular`, `react`)
 isSingleCountryWebsite      |    y    | Create language-master structure in example content
 optionDispatcherConfig      |   none  | Generate a dispatcher configuration module
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The property for including the frontend module was documented incorrectly. It defaults to not be created, but when provided if using the documentation it should allow for a frontend module to be created.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/adobe/aem-project-archetype/issues/318

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
If following the documentation "as is" you will not get the expected results. This can be a cause of frustration.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This was tested using both "as is" and committed changes to verify that this is the correct property name.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.