### PR TITLE
#331 - Adjusted log configs to align with the common use per environm…

### DIFF
--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/config.prod/org.apache.sling.commons.log.LogManager.factory.config-__appsFolderName__.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/config.prod/org.apache.sling.commons.log.LogManager.factory.config-__appsFolderName__.xml
@@ -2,7 +2,7 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
     xmlns:jcr="http://www.jcp.org/jcr/1.0" jcr:primaryType="sling:OsgiConfig"
     org.apache.sling.commons.log.file="logs/error.log"
-    org.apache.sling.commons.log.level="debug"
+    org.apache.sling.commons.log.level="error"
     org.apache.sling.commons.log.names="[${package}]"
     org.apache.sling.commons.log.additiv="true"
     org.apache.sling.commons.log.pattern="${symbol_escape}{0,date,yyyy-MM-dd HH:mm:ss.SSS} {4} [{3}] {5}" />

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/config.stage/org.apache.sling.commons.log.LogManager.factory.config-__appsFolderName__.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/config.stage/org.apache.sling.commons.log.LogManager.factory.config-__appsFolderName__.xml
@@ -2,7 +2,7 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
     xmlns:jcr="http://www.jcp.org/jcr/1.0" jcr:primaryType="sling:OsgiConfig"
     org.apache.sling.commons.log.file="logs/error.log"
-    org.apache.sling.commons.log.level="debug"
+    org.apache.sling.commons.log.level="warn"
     org.apache.sling.commons.log.names="[${package}]"
     org.apache.sling.commons.log.additiv="true"
     org.apache.sling.commons.log.pattern="${symbol_escape}{0,date,yyyy-MM-dd HH:mm:ss.SSS} {4} [{3}] {5}" />


### PR DESCRIPTION
…ent, and Cloud Manager's log tailing capabilities

See details of changes in #331.

In general, this sets the log configs for the project's package as follows:

1) All project logs are piped to `logs/error.log` as additive logs.
1) Default project log level to DEBUG
2) `stage` runmode logs as WARN
3) `prod` runmode logs at ERROR


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Change in existing functionality to better align w/ real-world use
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.