### PR TITLE
Archetype without Core Comp Dependency for Cloud Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ To generate a project, adjust the following command line to your needs:
 
 * Set `aemVersion=cloud` for [AEM as a Cloud Service](https://docs.adobe.com/content/help/en/experience-manager-cloud-service/landing/home.html);  
  Set `aemVersion=6.5.0` for [Adobe Managed Services](https://github.com/adobe/aem-project-archetype/tree/master/src/main/archetype/dispatcher.ams), or on-premise.
+ The Core Components dependency is only added for non cloud aem versions as the Core Components are provided OOTB for AEM as a Cloud 
+ Service.
 * Adjust `appTitle="My Site"` to define the website title and components groups.
 * Adjust `appId="mysite"` to define the Maven artifactId, the component, config and content folder names, as well as client library names.
 * Adjust `groupId="com.mysite"` to define the Maven groupId and the Java Source Package.

--- a/src/main/archetype/all/pom.xml
+++ b/src/main/archetype/all/pom.xml
@@ -70,6 +70,7 @@
                             <target>/apps/${appId}-vendor-packages/install</target>
                         </embedded>
 #end
+#if ( $aemVersion != "cloud" )
                         <embedded>
                             <groupId>com.adobe.cq</groupId>
                             <artifactId>core.wcm.components.content</artifactId>
@@ -82,6 +83,7 @@
                             <type>zip</type>
                             <target>/apps/${appId}-vendor-packages/application/install</target>
                         </embedded>
+#end
 #if ( $includeExamples == "y" )
                         <embedded>
                             <groupId>com.adobe.cq</groupId>
@@ -220,7 +222,7 @@
             <artifactId>spa.project.core.core</artifactId>
         </dependency>
 #end
-
+#if ( $aemVersion != "cloud" )
         <dependency>
             <groupId>com.adobe.cq</groupId>
             <artifactId>core.wcm.components.content</artifactId>
@@ -231,6 +233,7 @@
             <artifactId>core.wcm.components.config</artifactId>
             <type>zip</type>
         </dependency>
+#end
 #if ( $includeExamples == "y" )
         <dependency>
             <groupId>com.adobe.cq</groupId>

--- a/src/main/archetype/core/pom.xml
+++ b/src/main/archetype/core/pom.xml
@@ -86,7 +86,7 @@ Import-Package: javax.annotation;version=0.0.0,*
             <artifactId>slf4j-test</artifactId>
             <scope>test</scope>
         </dependency>
-#if ( $aemVersion.startsWith("6.") )
+#if ( $aemVersion != "cloud" )
         <!-- OSGi Dependencies -->
         <dependency>
             <groupId>org.osgi</groupId>

--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -73,7 +73,9 @@
         <sling.password>admin</sling.password>
         <vault.user>admin</vault.user>
         <vault.password>admin</vault.password>
+#if ( $aemVersion != "cloud" || $includeExamples == "y")
         <core.wcm.components.version>2.8.0</core.wcm.components.version>
+#end
         <bnd.version>5.0.0</bnd.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -589,7 +591,7 @@ Bundle-DocURL:
     <!-- ====================================================================== -->
     <dependencyManagement>
         <dependencies>
-#if ( $aemVersion.startsWith("6.") )
+#if ( $aemVersion != "cloud" )
             <!-- OSGi Dependencies -->
             <dependency>
                 <groupId>org.osgi</groupId>
@@ -719,14 +721,6 @@ Bundle-DocURL:
                 <version>5.7.4</version>
                 <scope>provided</scope>
             </dependency>
-#else
-            <dependency>
-                <groupId>com.adobe.aem</groupId>
-                <artifactId>aem-sdk-api</artifactId>
-                <version>${aem.sdk.api}</version>
-                <scope>provided</scope>
-            </dependency>
-#end
             <dependency>
                 <groupId>com.adobe.cq</groupId>
                 <artifactId>core.wcm.components.core</artifactId>
@@ -744,6 +738,14 @@ Bundle-DocURL:
                 <type>zip</type>
                 <version>${core.wcm.components.version}</version>
             </dependency>
+#else
+            <dependency>
+                <groupId>com.adobe.aem</groupId>
+                <artifactId>aem-sdk-api</artifactId>
+                <version>${aem.sdk.api}</version>
+                <scope>provided</scope>
+            </dependency>
+#end
 #if ( $includeExamples == "y" )
             <dependency>
                 <groupId>com.adobe.cq</groupId>

--- a/src/main/archetype/ui.apps/pom.xml
+++ b/src/main/archetype/ui.apps/pom.xml
@@ -63,6 +63,7 @@
                         </repositoryStructurePackage>
                     </repositoryStructurePackages>
                     <embeddeds>
+#if ( $aemVersion != "cloud" )
                         <embedded>
                             <groupId>com.adobe.cq</groupId>
                             <artifactId>core.wcm.components.core</artifactId>
@@ -73,6 +74,7 @@
                             <artifactId>${rootArtifactId}.core</artifactId>
                             <target>/apps/${appId}/install</target>
                         </embedded>
+#end
 #if ( $isSpaProject )
                         <embedded>
                             <groupId>com.adobe.aem</groupId>
@@ -89,6 +91,7 @@
                         </subPackage>
 #end
                     </subPackages>
+#if ( $aemVersion != "cloud" )
                     <dependencies>
                         <dependency>
                             <groupId>com.adobe.cq</groupId>
@@ -99,6 +102,7 @@
                             <artifactId>core.wcm.components.config</artifactId>
                         </dependency>
                     </dependencies>
+#end
                 </configuration>
             </plugin>
             <plugin>
@@ -168,17 +172,17 @@
             <artifactId>spa.project.core.core</artifactId>
         </dependency>
 #end
-
-        <dependency>
-            <groupId>com.adobe.cq</groupId>
-            <artifactId>core.wcm.components.core</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>${groupId}</groupId>
             <artifactId>${rootArtifactId}.ui.apps.structure</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
+        </dependency>
+
+#if ( $aemVersion != "cloud" )
+        <dependency>
+            <groupId>com.adobe.cq</groupId>
+            <artifactId>core.wcm.components.core</artifactId>
         </dependency>
 
         <dependency>
@@ -192,7 +196,7 @@
             <artifactId>core.wcm.components.config</artifactId>
             <type>zip</type>
         </dependency>
-#if ( $aemVersion.startsWith("6.") )
+
         <dependency>
             <groupId>com.adobe.aem</groupId>
             <artifactId>uber-jar</artifactId>

--- a/src/main/archetype/ui.frontend.angular/package.json
+++ b/src/main/archetype/ui.frontend.angular/package.json
@@ -32,6 +32,7 @@
     "@angular/cli": "~8.3.20",
     "@angular/compiler-cli": "~8.2.14",
     "@angular/language-service": "~8.2.14",
+    "@babel/compat-data": "~7.8.0",
     "@types/jasmine": "~3.3.8",
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "~8.9.4",


### PR DESCRIPTION
- add core components dependency only for aemVersion != cloud