### PR TITLE
Added 'watch' and 'aemsync' npm modules to sync frontend.general upda…

### DIFF
--- a/src/main/archetype/ui.frontend.general/package.json
+++ b/src/main/archetype/ui.frontend.general/package.json
@@ -12,7 +12,9 @@
   "scripts": {
     "dev": "webpack -d --env dev --config ./webpack.dev.js && clientlib --verbose",
     "prod": "webpack -p --config ./webpack.prod.js && clientlib --verbose",
-    "start": "webpack-dev-server --open --config ./webpack.dev.js"
+    "start": "webpack-dev-server --open --config ./webpack.dev.js",
+    "sync": "aemsync -d -p ../ui.apps/src/main/content",
+    "watch": "webpack-dev-server --config ./webpack.dev.js --env.writeToDisk & watch 'clientlib' ./dist & aemsync -w ../ui.apps/src/main/content"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
@@ -22,6 +24,7 @@
     "@typescript-eslint/parser": "^2.14.0",
     "acorn": "^6.1.0",
     "aem-clientlib-generator": "^1.4.3",
+    "aemsync": "^4.0.1",
     "autoprefixer": "^9.2.1",
     "browserslist": "^4.2.1",
     "clean-webpack-plugin": "^3.0.0",
@@ -43,6 +46,7 @@
     "ts-loader": "^5.3.3",
     "tsconfig-paths-webpack-plugin": "^3.2.0",
     "typescript": "^3.3.3333",
+    "watch": "^1.0.2",
     "webpack": "^4.27.1",
     "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^3.9.0",

--- a/src/main/archetype/ui.frontend.general/webpack.dev.js
+++ b/src/main/archetype/ui.frontend.general/webpack.dev.js
@@ -5,20 +5,26 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 const SOURCE_ROOT = __dirname + '/src/main/webpack';
 
-module.exports = merge(common, {
-    mode: 'development',
-    devtool: 'inline-source-map',
-    performance: { hints: 'warning' },
-    plugins: [
-        new HtmlWebpackPlugin({
-            template: path.resolve(__dirname, SOURCE_ROOT + '/static/index.html')
-        })
-    ],
-    devServer: {
-        inline: true,
-        proxy: [{
-            context: ['/content', '/etc.clientlibs'],
-            target: 'http://localhost:4502',
-        }]
-    }
-});
+module.exports = env => {
+    const writeToDisk = env && Boolean(env.writeToDisk);
+
+    return merge(common, {
+        mode: 'development',
+        devtool: 'inline-source-map',
+        performance: { hints: 'warning' },
+        plugins: [
+            new HtmlWebpackPlugin({
+                template: path.resolve(__dirname, SOURCE_ROOT + '/static/index.html')
+            })
+        ],
+        devServer: {
+            inline: true,
+            proxy: [{
+                context: ['/content', '/etc.clientlibs'],
+                target: 'http://localhost:4502',
+            }],
+            writeToDisk,
+            liveReload: !writeToDisk
+        }
+    });
+}


### PR DESCRIPTION
…tes on default port

## Description

Created two new NPM scripts in the frontend.general.
- `sync` does a push of `ui.apps/src/main/content`
- `watch` starts the webpack-dev-server with writeToDisk set to true and live reload set to false (live reload is turned off to prevent refreshing on 4502). When dist folder is changed, aem-clientlib-generator is ran, which will affect the clientlib folders that are being watched by aemsync.

I have only applied this to frontend.general (Angular and React already have aemsync, although the usage differs slightly).

When a file is saved, developer will see webpack compilation and then aemsync in terminal. After aemsync output, changes will be on 4502 after refresh.

## Related Issue

https://github.com/adobe/aem-project-archetype/issues/236

## Motivation and Context

Ease of development for developers that want to see their CSS and JS changes quickly on 4502.

## How Has This Been Tested?

Changes were initially made on a test project, then ported onto archetype. Code was retested after generating a fresh new project with reinstalled archetype.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Change only includes optional additions to npm scripts/webpack.

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

I had an experience where the first new reinstallation of the archetype threw an error from Checkstyle for tabs inside of aemsync in node_modules. I was unable to reproduce this error on further installations, but I would expect Checkstyle to avoid node_modules.