### PR TITLE
Fix wrong path to component scss files

### DIFF
--- a/src/main/archetype/ui.frontend.general/src/main/webpack/site/main.scss
+++ b/src/main/archetype/ui.frontend.general/src/main/webpack/site/main.scss
@@ -1,5 +1,5 @@
 
 @import 'variables';
 @import 'base';
-@import './components/*.scss';
+@import '../components/*.scss';
 @import './styles/*.scss';


### PR DESCRIPTION
The component based scss files are not merged by the frontend build as the path reference is wrong.