### PR TITLE
Use Maven central for the AEM as a cloud service SDK

### DIFF
--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -432,18 +432,6 @@ Bundle-DocURL:
                         <enabled>false</enabled>
                     </snapshots>
                 </repository>
-                <repository>
-                    <id>adobe-aem-releases</id>
-                    <name>Adobe AEM Repository</name>
-                    <url>https://downloads.experiencecloud.adobe.com/content/maven/public</url>
-                    <releases>
-                        <enabled>true</enabled>
-                        <updatePolicy>never</updatePolicy>
-                    </releases>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </repository>
             </repositories>
 
             <pluginRepositories>

--- a/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -156,7 +156,7 @@ def removeModule(pomFile, module) {
 }
 
 def getLatestSDK(archetypeVersion) {
-    def metadata = new XmlSlurper().parse("https://downloads.experiencecloud.adobe.com/content/maven/public/com/adobe/aem/aem-sdk-api/maven-metadata.xml?archetype=" + archetypeVersion)
+    def metadata = new XmlSlurper().parse("https://repo1.maven.org/maven2/com/adobe/aem/aem-sdk-api/maven-metadata.xml")
     def sdkVersion = metadata.versioning.latest
     if (sdkVersion == null || sdkVersion == "") {
         sdkVersion = System.console().readLine("Cannot get latest SDK version, please provide it manually: ")


### PR DESCRIPTION
## Use Maven central for the AEM as a cloud service SDK

See #395

## Related Issue

See #395

## Motivation and Context

The build will be faster as it does not have to query an additional Maven repository. Also, for corporate environments, fewer firewall exceptions to ask for.

## How Has This Been Tested?

- ran the build
- generated a project using the archetype
- built the generated project

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.