### PR TITLE
Change group id to com.adobe.aem

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To generate a project, adjust the following command line to your needs:
 
 ```
 mvn -B archetype:generate \
- -D archetypeGroupId=com.adobe.granite.archetypes \
+ -D archetypeGroupId=com.adobe.aem \
  -D archetypeArtifactId=aem-project-archetype \
  -D archetypeVersion=23 \
  -D aemVersion=cloud \

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.adobe.granite.archetypes</groupId>
+    <groupId>com.adobe.aem</groupId>
     <artifactId>aem-project-archetype</artifactId>
     <version>24-SNAPSHOT</version>
     <packaging>maven-archetype</packaging>


### PR DESCRIPTION
Change the group id to com.adobe.aem to align with public Adobe AEM artifacts.

## Description

This changes the group id to com.adobe.aem.
While this can be seen as an incompatible change, it is not affecting existing projects as an archetype is used once in the beginning. Changing the group id alligns with other public artifacts around AEM like the SDK for Cloud Service etc.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.