### PR TITLE
#420 - Aligned logger formats to AEM as a Cloud Service preferred for…

### DIFF
--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/config.prod/org.apache.sling.commons.log.LogManager.factory.config-__appId__.cfg.json
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/config.prod/org.apache.sling.commons.log.LogManager.factory.config-__appId__.cfg.json
@@ -1,0 +1,6 @@
+{
+    "org.apache.sling.commons.log.names":[
+      "${package}"
+    ],
+    "org.apache.sling.commons.log.level":"error"
+}

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/config.prod/org.apache.sling.commons.log.LogManager.factory.config-__appId__.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/config.prod/org.apache.sling.commons.log.LogManager.factory.config-__appId__.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
-    xmlns:jcr="http://www.jcp.org/jcr/1.0" jcr:primaryType="sling:OsgiConfig"
-    org.apache.sling.commons.log.file="logs/error.log"
-    org.apache.sling.commons.log.level="error"
-    org.apache.sling.commons.log.names="[${package}]"
-    org.apache.sling.commons.log.additiv="true"
-    org.apache.sling.commons.log.pattern="${symbol_escape}{0,date,yyyy-MM-dd HH:mm:ss.SSS} {4} [{3}] {5}" />

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/config.stage/org.apache.sling.commons.log.LogManager.factory.config-__appId__.cfg.json
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/config.stage/org.apache.sling.commons.log.LogManager.factory.config-__appId__.cfg.json
@@ -1,0 +1,6 @@
+{
+    "org.apache.sling.commons.log.names":[
+      "${package}"
+    ],
+    "org.apache.sling.commons.log.level":"warn"
+}

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/config.stage/org.apache.sling.commons.log.LogManager.factory.config-__appId__.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/config.stage/org.apache.sling.commons.log.LogManager.factory.config-__appId__.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
-    xmlns:jcr="http://www.jcp.org/jcr/1.0" jcr:primaryType="sling:OsgiConfig"
-    org.apache.sling.commons.log.file="logs/error.log"
-    org.apache.sling.commons.log.level="warn"
-    org.apache.sling.commons.log.names="[${package}]"
-    org.apache.sling.commons.log.additiv="true"
-    org.apache.sling.commons.log.pattern="${symbol_escape}{0,date,yyyy-MM-dd HH:mm:ss.SSS} {4} [{3}] {5}" />

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/config/org.apache.sling.commons.log.LogManager.factory.config-__appId__.cfg.json
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/config/org.apache.sling.commons.log.LogManager.factory.config-__appId__.cfg.json
@@ -1,0 +1,6 @@
+{
+    "org.apache.sling.commons.log.names":[
+      "${package}"
+    ],
+    "org.apache.sling.commons.log.level":"debug"
+}

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/config/org.apache.sling.commons.log.LogManager.factory.config-__appId__.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/config/org.apache.sling.commons.log.LogManager.factory.config-__appId__.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
-    xmlns:jcr="http://www.jcp.org/jcr/1.0" jcr:primaryType="sling:OsgiConfig"
-    org.apache.sling.commons.log.file="logs/error.log"
-    org.apache.sling.commons.log.level="debug"
-    org.apache.sling.commons.log.names="[${package}]"
-    org.apache.sling.commons.log.additiv="true"
-    org.apache.sling.commons.log.pattern="${symbol_escape}{0,date,yyyy-MM-dd HH:mm:ss.SSS} {4} [{3}] {5}" />


### PR DESCRIPTION
…mat and  minimal set of configuration parameters.

## Description

This changes the Logger OSGi configurations in 2 ways:

1. Replaces the OSGi config format to Cfg JSON (which is the recommended format for AEM as a Cloud Service).
2. Removes unnecessary config properties
    + log name is removed, and defaulting to `logs/error.log` which is the only Java error log AEM as a Cloud Service exposes
   + log pattern removed, so it uses the default error log, and discourages setting custom patterns which are not supported by AEM as a Cloud Service

**Note that the removal of unused properties results in an NPE in older Sling Logger Felix Console plugins, however, it is fixed for AEM as a Cloud Service.**

I'm not sure if there need to be special precautions here for AEM 6.5.x projects as this removal may cause an NPE there. If we must handle this, case, we should re-add the minimal set of config properties that prevent the NPE, and ensure the log pattern is correct (if that is a required property).

## Motivation and Context

Align with AEM as a Cloud Service practice.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.