### PR TITLE
CIF-1489 - Default product binding is missing in the Venia repo

### DIFF
--- a/src/main/archetype/ui.content/src/main/content/META-INF/vault/filter.xml
+++ b/src/main/archetype/ui.content/src/main/content/META-INF/vault/filter.xml
@@ -4,7 +4,7 @@
     <filter root="/content/${appId}" mode="merge"/>
     <filter root="/content/dam/${appId}" mode="merge"/>
     <filter root="/content/experience-fragments/${appId}" mode="merge"/>
-#if ( $includeCommerce == "y" )
-    <filter root="/var/commerce/products" mode="merge"/>
+#if ( $includeCommerce == "y" and $aemVersion != "cloud")
+    <filter root="/var/commerce/products/${appId}-default" mode="merge"/>
 #end
 </workspaceFilter>

--- a/src/main/archetype/ui.content/src/main/content/META-INF/vault/filter.xml
+++ b/src/main/archetype/ui.content/src/main/content/META-INF/vault/filter.xml
@@ -4,4 +4,7 @@
     <filter root="/content/${appId}" mode="merge"/>
     <filter root="/content/dam/${appId}" mode="merge"/>
     <filter root="/content/experience-fragments/${appId}" mode="merge"/>
+#if ( $includeCommerce == "y" )
+    <filter root="/var/commerce/products" mode="merge"/>
+#end
 </workspaceFilter>

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__appId__/settings/cloudconfigs/commerce/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__appId__/settings/cloudconfigs/commerce/.content.xml
@@ -12,6 +12,7 @@
         cq:template="/libs/commerce/gui/components/configuration/page/template"
         sling:resourceType="commerce/gui/components/configuration/page"
         cq:catalogDataResourceProviderFactory="magento-graphql"
+        cq:catalogPath="/var/commerce/products/${appId}-default"
         cq:catalogIdentifier="default"
         cq:graphqlClient="default"
         magentoRootCategoryId="2"

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/var/commerce/products/__appId__-default/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/var/commerce/products/__appId__-default/.content.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+          xmlns:cq="http://www.day.com/jcr/cq/1.0"
+          xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="sling:Folder"
+          jcr:title="${appTitle}-default"
+          cq:conf="/conf/${appId}">
+</jcr:root>

--- a/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -84,7 +84,7 @@ if (includeCommerce == "n") {
     assert new File("$appsFolder/config/com.adobe.cq.commerce.core.components.internal.services.UrlProviderImpl.config").delete()
     assert new File("$appsFolder/config/com.adobe.cq.commerce.core.components.internal.servlets.SpecificPageFilterFactory-default.config").delete()
     assert new File("$confFolder/cloudconfigs/commerce").deleteDir()
-    assert new File("$varFolder/commerce/products").deleteDir();
+    assert new File("$varFolder").deleteDir();
 
     def packageFolder = javaPackage.replaceAll("\\.", "/")
     assert new File(coreBundle, "src/main/java/$packageFolder/core/models/commerce").deleteDir()
@@ -95,6 +95,7 @@ if (includeCommerce == "n") {
 } else {
     if (aemVersion == "cloud") {
         assert new File("$appsFolder/config/com.adobe.cq.commerce.graphql.client.impl.GraphqlClientImpl-default.config").delete()
+        assert new File("$varFolder").deleteDir()
     }
 }
 

--- a/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -25,6 +25,7 @@ def includeCommerce = request.getProperties().get("includeCommerce")
 def appsFolder = new File("$uiAppsPackage/src/main/content/jcr_root/apps/$appId")
 def confFolder = new File("$uiContentPackage/src/main/content/jcr_root/conf/$appId")
 def contentFolder = new File("$uiContentPackage/src/main/content/jcr_root/content/$appId")
+def varFolder = new File("$uiContentPackage/src/main/content/jcr_root/var")
 
 if (includeErrorHandler == "n") {
     assert new File(uiAppsPackage, "src/main/content/jcr_root/apps/sling").deleteDir()
@@ -83,6 +84,8 @@ if (includeCommerce == "n") {
     assert new File("$appsFolder/config/com.adobe.cq.commerce.core.components.internal.services.UrlProviderImpl.config").delete()
     assert new File("$appsFolder/config/com.adobe.cq.commerce.core.components.internal.servlets.SpecificPageFilterFactory-default.config").delete()
     assert new File("$confFolder/cloudconfigs/commerce").deleteDir()
+    assert new File("$varFolder/commerce/products").deleteDir();
+
     def packageFolder = javaPackage.replaceAll("\\.", "/")
     assert new File(coreBundle, "src/main/java/$packageFolder/core/models/commerce").deleteDir()
     assert new File(coreBundle, "src/test/java/$packageFolder/core/models/commerce").deleteDir()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Create the `/var/commerce/products/${appId}-default` folder when the project includes commerce features, but not for the `cloud` type.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

CIF-1489

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Feature parity with the AEM CIF Project Archetype

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Functional testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.