### PR TITLE
CIF-1538 - Expose CIF page paths in xfpage property dialog

### DIFF
--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/components/xfpage/_cq_dialog/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/components/xfpage/_cq_dialog/.content.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Experience Fragment"
+    sling:resourceType="cq/gui/components/authoring/dialog"
+    extraClientlibs="[cq.common.wcm,core.wcm.page.properties,cq.wcm.msm.properties,cq.siteadmin.admin.properties,cq.experience-fragments.properties.tabs,cq.experience-fragments.target.properties]"
+    mode="edit">
+    <content
+        granite:class="cq-dialog-content-page"
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="granite/ui/components/coral/foundation/container">
+        <items jcr:primaryType="nt:unstructured">
+            <tabs
+                granite:class="cq-siteadmin-admin-properties-tabs"
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="granite/ui/components/coral/foundation/tabs"
+                size="L">
+                <items jcr:primaryType="nt:unstructured">
+                    <commerce
+                        cq:showOnCreate="{Boolean}true"
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Commerce"
+                        sling:orderBefore="cloudservices"
+                        sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns">
+                        <items jcr:primaryType="nt:unstructured">
+                            <column
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/container">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <pagesSection
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Commerce Pages"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/fieldset">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <productPage
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="cq/gui/components/coral/common/form/pagefield"
+                                                fieldDescription="Path to CIF product page."
+                                                fieldLabel="Product Page"
+                                                name="./cq:cifProductPage"
+                                                rootPath="/content"/>
+                                            <categoryPage
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="cq/gui/components/coral/common/form/pagefield"
+                                                fieldDescription="Path to CIF category page."
+                                                fieldLabel="Category Page"
+                                                name="./cq:cifCategoryPage"
+                                                rootPath="/content"/>
+                                            <searchResultsPage
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="cq/gui/components/coral/common/form/pagefield"
+                                                fieldDescription="Path to search results page."
+                                                fieldLabel="Search Results Page"
+                                                name="./cq:cifSearchResultsPage"
+                                                rootPath="/content"/>
+                                            <addressBookPage
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="cq/gui/components/coral/common/form/pagefield"
+                                                fieldDescription="Path to address book page."
+                                                fieldLabel="Address Book Page"
+                                                name="./cq:cifAddressBookPage"
+                                                rootPath="/content"/>
+                                            <myAccountPage
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="cq/gui/components/coral/common/form/pagefield"
+                                                fieldDescription="Path to my account page."
+                                                fieldLabel="My Account Page"
+                                                name="./cq:cifMyAccountPage"
+                                                rootPath="/content"/>
+                                        </items>
+                                    </pagesSection>
+                                </items>
+                            </column>
+                        </items>
+                    </commerce>
+                </items>
+            </tabs>
+        </items>
+    </content>
+</jcr:root>

--- a/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -83,6 +83,7 @@ if (includeCommerce == "n") {
     assert new File("$appsFolder/config/com.adobe.cq.commerce.graphql.client.impl.GraphqlClientImpl-default.config").delete()
     assert new File("$appsFolder/config/com.adobe.cq.commerce.core.components.internal.services.UrlProviderImpl.config").delete()
     assert new File("$appsFolder/config/com.adobe.cq.commerce.core.components.internal.servlets.SpecificPageFilterFactory-default.config").delete()
+    assert new File("$appsFolder/components/xfpage/_cq_dialog").deleteDir()
     assert new File("$confFolder/cloudconfigs/commerce").deleteDir()
     assert new File("$varFolder").deleteDir();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* It is now possible to define the CIF pages in the properties of the `xfpage` component. Only for `includeCommerce=y`.

## Related Issue

https://github.com/adobe/aem-cif-guides-venia/pull/30
https://github.com/adobe/aem-core-cif-components/pull/374

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.