### PR TITLE
componentGroupName is not defined in generated project

### DIFF
--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -98,6 +98,7 @@
 #if ( $aemVersion == "cloud")
         <aem.sdk.api>SDK_VERSION</aem.sdk.api>
 #end
+        <componentGroupName>$appTitle</componentGroupName>
     </properties>
 
     <build>


### PR DESCRIPTION

## Description

componentGroupName is not defined in generated project. So it currently only shows as :

![image](https://user-images.githubusercontent.com/37147400/91174931-4309cd00-e6e0-11ea-9be7-535068e5d355.png)

fixed it to use whatever is set as appTitle in archetype

## Related Issue
fixes #386

## How Has This Been Tested?

local building and running archetype 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x ] All new and existing tests passed.