### PR TITLE
Use consistent indentation in the dispatcher configuration

### DIFF
--- a/src/main/archetype/dispatcher.ams/assembly.xml
+++ b/src/main/archetype/dispatcher.ams/assembly.xml
@@ -1,18 +1,18 @@
 <assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
-  <id>distribution</id>
-  <formats>
-    <format>zip</format>
-  </formats>
-  <includeBaseDirectory>false</includeBaseDirectory>
-  <fileSets>
-    <fileSet>
-      <directory>${basedir}/src</directory>
-      <includes>
-        <include>**/*</include>
-      </includes>
-      <outputDirectory></outputDirectory>
-    </fileSet>
-  </fileSets>
+    <id>distribution</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>${basedir}/src</directory>
+            <includes>
+                <include>**/*</include>
+            </includes>
+            <outputDirectory></outputDirectory>
+        </fileSet>
+    </fileSets>
 </assembly>

--- a/src/main/archetype/dispatcher.ams/pom.xml
+++ b/src/main/archetype/dispatcher.ams/pom.xml
@@ -2,44 +2,44 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <!-- ====================================================================== -->
-  <!-- P A R E N T  P R O J E C T  D E S C R I P T I O N                      -->
-  <!-- ====================================================================== -->
-  <parent>
-    <groupId>${groupId}</groupId>
-    <artifactId>${rootArtifactId}</artifactId>
-    <version>${version}</version>
-    <relativePath>../pom.xml</relativePath>
-  </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <!-- ====================================================================== -->
+    <!-- P A R E N T  P R O J E C T  D E S C R I P T I O N                      -->
+    <!-- ====================================================================== -->
+    <parent>
+        <groupId>${groupId}</groupId>
+        <artifactId>${rootArtifactId}</artifactId>
+        <version>${version}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
 
-  <artifactId>${artifactId}</artifactId>
-  <name>${appTitle} - Dispatcher</name>
-  <packaging>pom</packaging>
-  <description>HTTP &amp; Dispatcher configurations for ${appTitle}</description>
+    <artifactId>${artifactId}</artifactId>
+    <name>${appTitle} - Dispatcher</name>
+    <packaging>pom</packaging>
+    <description>HTTP &amp; Dispatcher configurations for ${appTitle}</description>
 
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.1.1</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>single</goal>
-            </goals>
-            <configuration>
-              <descriptors>
-                <descriptor>assembly.xml</descriptor>
-              </descriptors>
-              <appendAssemblyId>false</appendAssemblyId>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>assembly.xml</descriptor>
+                            </descriptors>
+                            <appendAssemblyId>false</appendAssemblyId>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/archetype/dispatcher.ams/src/conf.d/autoindex.conf
+++ b/src/main/archetype/dispatcher.ams/src/conf.d/autoindex.conf
@@ -20,9 +20,9 @@ IndexOptions FancyIndexing HTMLTable VersionSort
 Alias /icons/ "/usr/share/httpd/icons/"
 
 <Directory "/usr/share/httpd/icons">
-    Options Indexes MultiViews FollowSymlinks
-    AllowOverride None
-    Require all granted
+	Options Indexes MultiViews FollowSymlinks
+	AllowOverride None
+	Require all granted
 </Directory>
 
 #

--- a/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/000_unhealthy_author.vhost
+++ b/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/000_unhealthy_author.vhost
@@ -1,9 +1,9 @@
 <VirtualHost *:80>
 	ServerName	unhealthyauthor
 	ServerAlias	${AUTHOR_DEFAULT_HOSTNAME}
-	
+
 	DocumentRoot	/mnt/var/www/default
-	
+
 	<Directory />
 		Options FollowSymLinks
 		AllowOverride None

--- a/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/000_unhealthy_publish.vhost
+++ b/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/000_unhealthy_publish.vhost
@@ -1,9 +1,9 @@
 <VirtualHost *:80>
 	ServerName	unhealthypublish
 	ServerAlias	${PUBLISH_DEFAULT_HOSTNAME}
-	
+
 	DocumentRoot	/mnt/var/www/default
-	
+
 	<Directory />
 		Options FollowSymLinks
 		AllowOverride None
@@ -20,8 +20,8 @@
 		Require all granted
 	</Directory>
 	<IfModule mod_headers.c>
-			Header always add X-Dispatcher ${DISP_ID}
-			Header always add X-Vhost "unhealthy-publish"
+		Header always add X-Dispatcher ${DISP_ID}
+		Header always add X-Vhost "unhealthy-publish"
 	</IfModule>
 	<IfModule mod_rewrite.c>
 		ReWriteEngine   on

--- a/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/__appId___publish.vhost
+++ b/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/__appId___publish.vhost
@@ -10,10 +10,10 @@ PassEnv DISP_ID
 	DocumentRoot	${PUBLISH_DOCROOT}
 	# Add header breadcrumbs for help in troubleshooting
 	<IfModule mod_headers.c>
-			Header always add X-Dispatcher ${DISP_ID}
-			Header always add X-Vhost "publish"
-			Header merge X-Frame-Options SAMEORIGIN "expr=%{resp:X-Frame-Options}!='SAMEORIGIN'"
-			Header merge X-Content-Type-Options nosniff "expr=%{resp:X-Content-Type-Options}!='nosniff'"
+		Header always add X-Dispatcher ${DISP_ID}
+		Header always add X-Vhost "publish"
+		Header merge X-Frame-Options SAMEORIGIN "expr=%{resp:X-Frame-Options}!='SAMEORIGIN'"
+		Header merge X-Content-Type-Options nosniff "expr=%{resp:X-Content-Type-Options}!='nosniff'"
 		# Make sure proxies don't deliver the wrong content
 		Header append Vary User-Agent env=!dont-vary
 	</IfModule>

--- a/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/aem_author.vhost
+++ b/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/aem_author.vhost
@@ -3,18 +3,18 @@
 PassEnv DISP_ID
 
 <VirtualHost *:80>
-    # allowing slashes in the URL to be encoded and still honored
-    AllowEncodedSlashes On
+	# allowing slashes in the URL to be encoded and still honored
+	AllowEncodedSlashes On
 	ServerName	"author"
 	ServerAlias	${AUTHOR_DEFAULT_HOSTNAME}
 	# Use a special doc root that doesn't overlap publish doc roots or it wont fetch from author each time and authors wont see their changes
 	DocumentRoot	${AUTHOR_DOCROOT}
 	# Add header breadcrumbs for help in troubleshooting
 	<IfModule mod_headers.c>
-			Header always add X-Dispatcher ${DISP_ID}
-			Header always add X-Vhost "author"
-			Header merge X-Frame-Options SAMEORIGIN "expr=%{resp:X-Frame-Options}!='SAMEORIGIN'"
-			Header merge X-Content-Type-Options nosniff "expr=%{resp:X-Content-Type-Options}!='nosniff'"
+		Header always add X-Dispatcher ${DISP_ID}
+		Header always add X-Vhost "author"
+		Header merge X-Frame-Options SAMEORIGIN "expr=%{resp:X-Frame-Options}!='SAMEORIGIN'"
+		Header merge X-Content-Type-Options nosniff "expr=%{resp:X-Content-Type-Options}!='nosniff'"
 		# Make sure proxies don't deliver the wrong content
 		Header append Vary User-Agent env=!dont-vary
 		# Force SSL for author
@@ -50,7 +50,7 @@ PassEnv DISP_ID
 		SetEnvIfNoCase Request_URI \
 		\.(?:gif|jpe?g|png)$ no-gzip dont-vary
 		# Don't compress AEM assets
-        SetEnvIfNoCase Request_URI assetdownload no-gzip dont-vary
+		SetEnvIfNoCase Request_URI assetdownload no-gzip dont-vary
 	</Directory>
 	<IfModule disp_apache2.c>
 		# Enabled to allow rewrites to take affect and not be ignored by the dispatcher module

--- a/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/aem_flush.vhost
+++ b/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/aem_flush.vhost
@@ -10,13 +10,13 @@ PassEnv DISP_ID
 	DocumentRoot	${PUBLISH_DOCROOT}
 	# Add header breadcrumbs for help in troubleshooting
 	<IfModule mod_headers.c>
-			Header always add X-Dispatcher ${DISP_ID}
-			Header always add X-Vhost "flush"
+		Header always add X-Dispatcher ${DISP_ID}
+		Header always add X-Vhost "flush"
 	</IfModule>
-        <Directory "${PUBLISH_DOCROOT}">
-                AllowOverride None
-                Require all granted
-        </Directory>
+	<Directory "${PUBLISH_DOCROOT}">
+		AllowOverride None
+		Require all granted
+	</Directory>
 	<Directory />
 		<IfModule disp_apache2.c>
 			SetHandler dispatcher-handler

--- a/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/aem_health.vhost
+++ b/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/aem_health.vhost
@@ -20,16 +20,16 @@ Listen 81
 		RequestReadTimeout header=65 body=65
 	</IfModule>
 	<IfModule mod_headers.c>
-			Header always add X-Dispatcher ${DISP_ID}
-			Header always add X-Vhost "health"
+		Header always add X-Dispatcher ${DISP_ID}
+		Header always add X-Vhost "health"
 	</IfModule>
 	<Directory "/var/www/cgi-bin">
 		AllowOverride None
 		Options None
 		Require all granted
 	</Directory>
- 	ScriptAlias /health/ "/var/www/cgi-bin/health/"
- 	ScriptAlias /eagle/ "/var/www/cgi-bin/health/"
+	ScriptAlias /health/ "/var/www/cgi-bin/health/"
+	ScriptAlias /eagle/ "/var/www/cgi-bin/health/"
 </VirtualHost>
 
 <VirtualHost *:80>
@@ -42,14 +42,14 @@ Listen 81
 		RequestReadTimeout header=65 body=65
 	</IfModule>
 	<IfModule mod_headers.c>
-			Header always add X-Dispatcher ${DISP_ID}
-			Header always add X-Vhost "health"
+		Header always add X-Dispatcher ${DISP_ID}
+		Header always add X-Vhost "health"
 	</IfModule>
 	<Directory "/var/www/cgi-bin">
 		AllowOverride None
 		Options None
 		Require all granted
 	</Directory>
- 	ScriptAlias /health/ "/var/www/cgi-bin/health/"
- 	ScriptAlias /eagle/ "/var/www/cgi-bin/health/"
+	ScriptAlias /health/ "/var/www/cgi-bin/health/"
+	ScriptAlias /eagle/ "/var/www/cgi-bin/health/"
 </VirtualHost>

--- a/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/aem_lc.vhost
+++ b/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/aem_lc.vhost
@@ -7,11 +7,11 @@
 	DocumentRoot	${LIVECYCLE_DOCROOT}
 	# Add header breadcrumbs for help in troubleshooting
 	<IfModule mod_headers.c>
-			Header always add X-Dispatcher ${DISP_ID}
-			Header always add X-Vhost "livecycle"
-			Header merge X-Frame-Options SAMEORIGIN "expr=%{resp:X-Frame-Options}!='SAMEORIGIN'"
-			Header always set Strict-Transport-Security "max-age=63072000; includeSubdomains;"
-			Header merge X-Content-Type-Options nosniff "expr=%{resp:X-Content-Type-Options}!='nosniff'"
+		Header always add X-Dispatcher ${DISP_ID}
+		Header always add X-Vhost "livecycle"
+		Header merge X-Frame-Options SAMEORIGIN "expr=%{resp:X-Frame-Options}!='SAMEORIGIN'"
+		Header always set Strict-Transport-Security "max-age=63072000; includeSubdomains;"
+		Header merge X-Content-Type-Options nosniff "expr=%{resp:X-Content-Type-Options}!='nosniff'"
 		# Make sure proxies don't deliver the wrong content
 		Header append Vary User-Agent env=!dont-vary
 	</IfModule>

--- a/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/aem_publish.vhost
+++ b/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/aem_publish.vhost
@@ -4,7 +4,7 @@ PassEnv DISP_ID
 
 <VirtualHost *:80>
 	# allowing slashes in the URL to be encoded and still honored
-    AllowEncodedSlashes On
+	AllowEncodedSlashes On
 	ServerName	publish
 	# Put names of which domains are used for your published site/content here
 	ServerAlias	${PUBLISH_DEFAULT_HOSTNAME}
@@ -12,10 +12,10 @@ PassEnv DISP_ID
 	DocumentRoot	${PUBLISH_DOCROOT}
 	# Add header breadcrumbs for help in troubleshooting
 	<IfModule mod_headers.c>
-			Header always add X-Dispatcher ${DISP_ID}
-			Header always add X-Vhost "publish"
-			Header merge X-Frame-Options SAMEORIGIN "expr=%{resp:X-Frame-Options}!='SAMEORIGIN'"
-			Header merge X-Content-Type-Options nosniff "expr=%{resp:X-Content-Type-Options}!='nosniff'"
+		Header always add X-Dispatcher ${DISP_ID}
+		Header always add X-Vhost "publish"
+		Header merge X-Frame-Options SAMEORIGIN "expr=%{resp:X-Frame-Options}!='SAMEORIGIN'"
+		Header merge X-Content-Type-Options nosniff "expr=%{resp:X-Content-Type-Options}!='nosniff'"
 		# Make sure proxies don't deliver the wrong content
 		Header append Vary User-Agent env=!dont-vary
 		# Force SSL for author

--- a/src/main/archetype/dispatcher.ams/src/conf.d/logformat.conf
+++ b/src/main/archetype/dispatcher.ams/src/conf.d/logformat.conf
@@ -1,4 +1,4 @@
 # Logging format to capture the Host requested, and the referer to assure we get direct requests IP and proxied requests proper public	addresses in our log entries of	the access_log
 <IfModule log_config_module>
-        LogFormat "%h \"%{Host}i\" %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+	LogFormat "%h \"%{Host}i\" %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
 </IfModule>

--- a/src/main/archetype/dispatcher.ams/src/conf.d/mimetypes3d.conf
+++ b/src/main/archetype/dispatcher.ams/src/conf.d/mimetypes3d.conf
@@ -1,15 +1,15 @@
 ##This is needed,if there is any intention of caching 3D files on Publish/Dispatcher, otherwise the files will be served from cache with incorrect content types.
- <IfDefine !3D_MIMETYPE_ENABLED>
-   Define 3D_MIMETYPE_ENABLED 1
- </IfDefine>
+<IfDefine !3D_MIMETYPE_ENABLED>
+	 Define 3D_MIMETYPE_ENABLED 1
+</IfDefine>
 
- <If "${3D_MIMETYPE_ENABLED} == 1">
-    <IfModule mime_module>
-        AddType model/vnd.usdz+zip usdz
-        AddType model/gltf-binary glb
-        AddType model/gltf+json gltf
-        AddType application/x-tgif obj
-        AddType application/vnd.ms-pki.stl stl
-        AddType model/x-adobe-dn dn
-     </IfModule>
- </If>
+<If "${3D_MIMETYPE_ENABLED} == 1">
+	<IfModule mime_module>
+		AddType model/vnd.usdz+zip usdz
+		AddType model/gltf-binary glb
+		AddType model/gltf+json gltf
+		AddType application/x-tgif obj
+		AddType application/vnd.ms-pki.stl stl
+		AddType model/x-adobe-dn dn
+	 </IfModule>
+</If>

--- a/src/main/archetype/dispatcher.ams/src/conf.d/remoteip.conf
+++ b/src/main/archetype/dispatcher.ams/src/conf.d/remoteip.conf
@@ -2,9 +2,9 @@
 # Extract true client IP from header added by load balancer/CDN
 #
 <IfModule remoteip_module>
-    # valid for ALB, ELB, AppGateway or Load Balancer + CloudFront
-    RemoteIPHeader X-Forwarded-For
- 
-    # valid for ALB, ELB, AppGateway or Load Balancer + Akamai
-    #RemoteIPHeader True-Client-IP
+	# valid for ALB, ELB, AppGateway or Load Balancer + CloudFront
+	RemoteIPHeader X-Forwarded-For
+
+	# valid for ALB, ELB, AppGateway or Load Balancer + Akamai
+	#RemoteIPHeader True-Client-IP
 </IfModule>

--- a/src/main/archetype/dispatcher.ams/src/conf.d/security.conf
+++ b/src/main/archetype/dispatcher.ams/src/conf.d/security.conf
@@ -1,7 +1,7 @@
 TraceEnable off
 <Directory />
-    <Limit OPTIONS>
-        Order deny,allow
-        Deny from all
-    </Limit>
+	<Limit OPTIONS>
+		Order deny,allow
+		Deny from all
+	</Limit>
 </Directory>

--- a/src/main/archetype/dispatcher.ams/src/conf.d/userdir.conf
+++ b/src/main/archetype/dispatcher.ams/src/conf.d/userdir.conf
@@ -9,19 +9,19 @@
 # Otherwise, the client will only receive a "403 Forbidden" message.
 #
 <IfModule mod_userdir.c>
-    #
-    # UserDir is disabled by default since it can confirm the presence
-    # of a username on the system (depending on home directory
-    # permissions).
-    #
-    UserDir disabled
+	#
+	# UserDir is disabled by default since it can confirm the presence
+	# of a username on the system (depending on home directory
+	# permissions).
+	#
+	UserDir disabled
 
-    #
-    # To enable requests to /~user/ to serve the user's public_html
-    # directory, remove the "UserDir disabled" line above, and uncomment
-    # the following line instead:
-    #
-    # UserDir public_html
+	#
+	# To enable requests to /~user/ to serve the user's public_html
+	# directory, remove the "UserDir disabled" line above, and uncomment
+	# the following line instead:
+	#
+	# UserDir public_html
 </IfModule>
 
 #
@@ -29,8 +29,8 @@
 # for a site where these directories are restricted to read-only.
 #
 <Directory "/home/*/public_html">
-    AllowOverride FileInfo AuthConfig Limit Indexes
-    Options MultiViews Indexes SymLinksIfOwnerMatch IncludesNoExec
-    Require method GET POST OPTIONS
+	AllowOverride FileInfo AuthConfig Limit Indexes
+	Options MultiViews Indexes SymLinksIfOwnerMatch IncludesNoExec
+	Require method GET POST OPTIONS
 </Directory>
 

--- a/src/main/archetype/dispatcher.ams/src/conf.d/welcome.conf
+++ b/src/main/archetype/dispatcher.ams/src/conf.d/welcome.conf
@@ -6,13 +6,13 @@
 # NOTE: if this file is removed, it will be restored on upgrades.
 #
 <LocationMatch "^/+$">
-    Options -Indexes
-    ErrorDocument 403 /.noindex.html
+	Options -Indexes
+	ErrorDocument 403 /.noindex.html
 </LocationMatch>
 
 <Directory /usr/share/httpd/noindex>
-    AllowOverride None
-    Require all granted
+	AllowOverride None
+	Require all granted
 </Directory>
 
 Alias /.noindex.html /usr/share/httpd/noindex/index.html

--- a/src/main/archetype/dispatcher.ams/src/conf.d/whitelists/000_base_whitelist.rules
+++ b/src/main/archetype/dispatcher.ams/src/conf.d/whitelists/000_base_whitelist.rules
@@ -7,9 +7,9 @@
 
 # Setup a require any section so if any rules in there are matched it will allow them in
 <RequireAny>
-  # We make sure the environment variable AllowIP is enforced
-  Require env AllowIP
-  # Here are some rules for CIDR ip blocks and single addresses
-  # Require ip 192.150.16.0/23
-  # Require ip 120.242.180.10
+	# We make sure the environment variable AllowIP is enforced
+	Require env AllowIP
+	# Here are some rules for CIDR ip blocks and single addresses
+	# Require ip 192.150.16.0/23
+	# Require ip 120.242.180.10
 </RequireAny>

--- a/src/main/archetype/dispatcher.ams/src/conf.dispatcher.d/filters/ams_author_filters.any
+++ b/src/main/archetype/dispatcher.ams/src/conf.dispatcher.d/filters/ams_author_filters.any
@@ -13,7 +13,7 @@
 /0016 { /type "deny" /path "/content/ams/healthcheck/*"}
 /0017 { /type "deny" /url "/content/regent.html"}
 
- # allow some requests
+# allow some requests
 /0052 { /type "allow" /method "GET" /extension "html" /url "/system/sling/logout.html*" } # allow logout
 #Asset download defaults to deny but can be allowed in /etc/httpd/conf.d/variables/ams_default.vars
 /0070 { /type "${ASSET_DOWNLOAD_RULE}" /method "GET" /url "*.assetdownload.zip/assets.zip*" }

--- a/src/main/archetype/dispatcher.ams/src/conf.dispatcher.d/renders/ams_author_renders.any
+++ b/src/main/archetype/dispatcher.ams/src/conf.dispatcher.d/renders/ams_author_renders.any
@@ -1,6 +1,6 @@
 # Add values for author instances you'll pull content from
 /0 {
-  /hostname "${AUTHOR_IP}"
-  /port "${AUTHOR_PORT}"
-  /timeout "10000"
+	/hostname "${AUTHOR_IP}"
+	/port "${AUTHOR_PORT}"
+	/timeout "10000"
 }

--- a/src/main/archetype/dispatcher.ams/src/conf.dispatcher.d/renders/ams_lc_renders.any
+++ b/src/main/archetype/dispatcher.ams/src/conf.dispatcher.d/renders/ams_lc_renders.any
@@ -1,6 +1,6 @@
 # Add values for any livecycle instances you'll pull content from.
 /0 {
-  /hostname "${LIVECYCLE_IP}"
-  /port "${LIVECYCLE_PORT}"
-  /timeout "10000"
+	/hostname "${LIVECYCLE_IP}"
+	/port "${LIVECYCLE_PORT}"
+	/timeout "10000"
 }

--- a/src/main/archetype/dispatcher.ams/src/conf.dispatcher.d/renders/ams_publish_renders.any
+++ b/src/main/archetype/dispatcher.ams/src/conf.dispatcher.d/renders/ams_publish_renders.any
@@ -2,7 +2,7 @@
 # It's recommended to use paired sets of dispatchers to publishers
 # Example Dispatcher1 only grabs from Publisher1 but you don't have to and can list mulitple sources here
 /0 {
-  /hostname "${PUBLISH_IP}"
-  /port "${PUBLISH_PORT}"
-  /timeout "10000"
+	/hostname "${PUBLISH_IP}"
+	/port "${PUBLISH_PORT}"
+	/timeout "10000"
 }

--- a/src/main/archetype/dispatcher.ams/src/conf.modules.d/01-cgi.conf
+++ b/src/main/archetype/dispatcher.ams/src/conf.modules.d/01-cgi.conf
@@ -3,12 +3,12 @@
 # with a threaded MPM; mod_cgi with the prefork MPM.
 
 <IfModule mpm_worker_module>
-   LoadModule cgid_module modules/mod_cgid.so
+	LoadModule cgid_module modules/mod_cgid.so
 </IfModule>
 <IfModule mpm_event_module>
-   LoadModule cgid_module modules/mod_cgid.so
+	LoadModule cgid_module modules/mod_cgid.so
 </IfModule>
 <IfModule mpm_prefork_module>
-   LoadModule cgi_module modules/mod_cgi.so
+	LoadModule cgi_module modules/mod_cgi.so
 </IfModule>
 

--- a/src/main/archetype/dispatcher.ams/src/conf/httpd.conf
+++ b/src/main/archetype/dispatcher.ams/src/conf/httpd.conf
@@ -100,8 +100,8 @@ ServerAdmin root@localhost
 # <Directory> blocks below.
 #
 <Directory />
-    AllowOverride none
-    Require all denied
+	AllowOverride none
+	Require all denied
 </Directory>
 
 #
@@ -122,38 +122,38 @@ DocumentRoot "/var/www/html"
 # Relax access to content within /var/www.
 #
 <Directory "/var/www">
-    AllowOverride None
-    # Allow open access:
-    Require all granted
+	AllowOverride None
+	# Allow open access:
+	Require all granted
 </Directory>
 
 # Further relax access to the default document root:
 <Directory "/var/www/html">
-    #
-    # Possible values for the Options directive are "None", "All",
-    # or any combination of:
-    # Indexes Includes FollowSymLinks SymLinksifOwnerMatch ExecCGI MultiViews
-    #
-    # Note that "MultiViews" must be named *explicitly* --- "Options All"
-    # doesn't give it to you.
-    #
-    # The Options directive is both complicated and important.  Please see
-    # http://httpd.apache.org/docs/2.4/mod/core.html#options
-    # for more information.
-    #
-    Options Indexes FollowSymLinks
+	#
+	# Possible values for the Options directive are "None", "All",
+	# or any combination of:
+	# Indexes Includes FollowSymLinks SymLinksifOwnerMatch ExecCGI MultiViews
+	#
+	# Note that "MultiViews" must be named *explicitly* --- "Options All"
+	# doesn't give it to you.
+	#
+	# The Options directive is both complicated and important.  Please see
+	# http://httpd.apache.org/docs/2.4/mod/core.html#options
+	# for more information.
+	#
+	Options Indexes FollowSymLinks
 
-    #
-    # AllowOverride controls what directives may be placed in .htaccess files.
-    # It can be "All", "None", or any combination of the keywords:
-    # Options FileInfo AuthConfig Limit
-    #
-    AllowOverride None
+	#
+	# AllowOverride controls what directives may be placed in .htaccess files.
+	# It can be "All", "None", or any combination of the keywords:
+	# Options FileInfo AuthConfig Limit
+	#
+	AllowOverride None
 
-    #
-    # Controls who can get stuff from this server.
-    #
-    Require all granted
+	#
+	# Controls who can get stuff from this server.
+	#
+	Require all granted
 </Directory>
 
 #
@@ -161,7 +161,7 @@ DocumentRoot "/var/www/html"
 # is requested.
 #
 <IfModule dir_module>
-    DirectoryIndex index.html
+	DirectoryIndex index.html
 </IfModule>
 
 #
@@ -169,7 +169,7 @@ DocumentRoot "/var/www/html"
 # viewed by Web clients.
 #
 <Files ".ht*">
-    Require all denied
+	Require all denied
 </Files>
 
 #
@@ -189,62 +189,62 @@ ErrorLog "logs/error_log"
 LogLevel warn
 
 <IfModule log_config_module>
-    #
-    # The following directives define some format nicknames for use with
-    # a CustomLog directive (see below).
-    #
-    LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
-    LogFormat "%h %l %u %t \"%r\" %>s %b" common
+	#
+	# The following directives define some format nicknames for use with
+	# a CustomLog directive (see below).
+	#
+	LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+	LogFormat "%h %l %u %t \"%r\" %>s %b" common
 
-    <IfModule logio_module>
-      # You need to enable mod_logio.c to use %I and %O
-      LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combinedio
-    </IfModule>
+	<IfModule logio_module>
+		# You need to enable mod_logio.c to use %I and %O
+		LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combinedio
+	</IfModule>
 
-    #
-    # The location and format of the access logfile (Common Logfile Format).
-    # If you do not define any access logfiles within a <VirtualHost>
-    # container, they will be logged here.  Contrariwise, if you *do*
-    # define per-<VirtualHost> access logfiles, transactions will be
-    # logged therein and *not* in this file.
-    #
-    # CustomLog "logs/access_log" common
+	#
+	# The location and format of the access logfile (Common Logfile Format).
+	# If you do not define any access logfiles within a <VirtualHost>
+	# container, they will be logged here.  Contrariwise, if you *do*
+	# define per-<VirtualHost> access logfiles, transactions will be
+	# logged therein and *not* in this file.
+	#
+	# CustomLog "logs/access_log" common
 
-    #
-    # If you prefer a logfile with access, agent, and referer information
-    # (Combined Logfile Format) you can use the following directive.
-    #
-    CustomLog "logs/access_log" combined
+	#
+	# If you prefer a logfile with access, agent, and referer information
+	# (Combined Logfile Format) you can use the following directive.
+	#
+	CustomLog "logs/access_log" combined
 </IfModule>
 
 <IfModule alias_module>
-    #
-    # Redirect: Allows you to tell clients about documents that used to
-    # exist in your server's namespace, but do not anymore. The client
-    # will make a new request for the document at its new location.
-    # Example:
-    # Redirect permanent /foo http://www.example.com/bar
+	#
+	# Redirect: Allows you to tell clients about documents that used to
+	# exist in your server's namespace, but do not anymore. The client
+	# will make a new request for the document at its new location.
+	# Example:
+	# Redirect permanent /foo http://www.example.com/bar
 
-    #
-    # Alias: Maps web paths into filesystem paths and is used to
-    # access content that does not live under the DocumentRoot.
-    # Example:
-    # Alias /webpath /full/filesystem/path
-    #
-    # If you include a trailing / on /webpath then the server will
-    # require it to be present in the URL.  You will also likely
-    # need to provide a <Directory> section to allow access to
-    # the filesystem path.
+	#
+	# Alias: Maps web paths into filesystem paths and is used to
+	# access content that does not live under the DocumentRoot.
+	# Example:
+	# Alias /webpath /full/filesystem/path
+	#
+	# If you include a trailing / on /webpath then the server will
+	# require it to be present in the URL.  You will also likely
+	# need to provide a <Directory> section to allow access to
+	# the filesystem path.
 
-    #
-    # ScriptAlias: This controls which directories contain server scripts.
-    # ScriptAliases are essentially the same as Aliases, except that
-    # documents in the target directory are treated as applications and
-    # run by the server when requested rather than as documents sent to the
-    # client.  The same rules about trailing "/" apply to ScriptAlias
-    # directives as to Alias.
-    #
-    ScriptAlias /cgi-bin/ "/var/www/cgi-bin/"
+	#
+	# ScriptAlias: This controls which directories contain server scripts.
+	# ScriptAliases are essentially the same as Aliases, except that
+	# documents in the target directory are treated as applications and
+	# run by the server when requested rather than as documents sent to the
+	# client.  The same rules about trailing "/" apply to ScriptAlias
+	# directives as to Alias.
+	#
+	ScriptAlias /cgi-bin/ "/var/www/cgi-bin/"
 
 </IfModule>
 
@@ -253,57 +253,57 @@ LogLevel warn
 # CGI directory exists, if you have that configured.
 #
 <Directory "/var/www/cgi-bin">
-    AllowOverride None
-    Options None
-    Require all granted
+	AllowOverride None
+	Options None
+	Require all granted
 </Directory>
 
 <IfModule mime_module>
-    #
-    # TypesConfig points to the file containing the list of mappings from
-    # filename extension to MIME-type.
-    #
-    TypesConfig /etc/mime.types
+	#
+	# TypesConfig points to the file containing the list of mappings from
+	# filename extension to MIME-type.
+	#
+	TypesConfig /etc/mime.types
 
-    #
-    # AddType allows you to add to or override the MIME configuration
-    # file specified in TypesConfig for specific file types.
-    #
-    # AddType application/x-gzip .tgz
-    #
-    # AddEncoding allows you to have certain browsers uncompress
-    # information on the fly. Note: Not all browsers support this.
-    #
-    # AddEncoding x-compress .Z
-    # AddEncoding x-gzip .gz .tgz
-    #
-    # If the AddEncoding directives above are commented-out, then you
-    # probably should define those extensions to indicate media types:
-    #
-    AddType application/x-compress .Z
-    AddType application/x-gzip .gz .tgz
+	#
+	# AddType allows you to add to or override the MIME configuration
+	# file specified in TypesConfig for specific file types.
+	#
+	# AddType application/x-gzip .tgz
+	#
+	# AddEncoding allows you to have certain browsers uncompress
+	# information on the fly. Note: Not all browsers support this.
+	#
+	# AddEncoding x-compress .Z
+	# AddEncoding x-gzip .gz .tgz
+	#
+	# If the AddEncoding directives above are commented-out, then you
+	# probably should define those extensions to indicate media types:
+	#
+	AddType application/x-compress .Z
+	AddType application/x-gzip .gz .tgz
 
-    #
-    # AddHandler allows you to map certain file extensions to "handlers":
-    # actions unrelated to filetype. These can be either built into the server
-    # or added with the Action directive (see below)
-    #
-    # To use CGI scripts outside of ScriptAliased directories:
-    # (You will also need to add "ExecCGI" to the "Options" directive.)
-    #
-    # AddHandler cgi-script .cgi
+	#
+	# AddHandler allows you to map certain file extensions to "handlers":
+	# actions unrelated to filetype. These can be either built into the server
+	# or added with the Action directive (see below)
+	#
+	# To use CGI scripts outside of ScriptAliased directories:
+	# (You will also need to add "ExecCGI" to the "Options" directive.)
+	#
+	# AddHandler cgi-script .cgi
 
-    # For type maps (negotiated resources):
-    # AddHandler type-map var
+	# For type maps (negotiated resources):
+	# AddHandler type-map var
 
-    #
-    # Filters allow you to process content before it is sent to the client.
-    #
-    # To parse .shtml files for server-side includes (SSI):
-    # (You will also need to add "Includes" to the "Options" directive.)
-    #
-    AddType text/html .shtml
-    AddOutputFilter INCLUDES .shtml
+	#
+	# Filters allow you to process content before it is sent to the client.
+	#
+	# To parse .shtml files for server-side includes (SSI):
+	# (You will also need to add "Includes" to the "Options" directive.)
+	#
+	AddType text/html .shtml
+	AddOutputFilter INCLUDES .shtml
 </IfModule>
 
 #
@@ -316,12 +316,12 @@ LogLevel warn
 AddDefaultCharset UTF-8
 
 <IfModule mime_magic_module>
-    #
-    # The mod_mime_magic module allows the server to use various hints from the
-    # contents of the file itself to determine its type.  The MIMEMagicFile
-    # directive tells the module where the hint definitions are located.
-    #
-    MIMEMagicFile conf/magic
+	#
+	# The mod_mime_magic module allows the server to use various hints from the
+	# contents of the file itself to determine its type.  The MIMEMagicFile
+	# directive tells the module where the hint definitions are located.
+	#
+	MIMEMagicFile conf/magic
 </IfModule>
 
 #

--- a/src/main/archetype/dispatcher.cloud/assembly.xml
+++ b/src/main/archetype/dispatcher.cloud/assembly.xml
@@ -1,18 +1,18 @@
 <assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
-  <id>distribution</id>
-  <formats>
-    <format>zip</format>
-  </formats>
-  <includeBaseDirectory>false</includeBaseDirectory>
-  <fileSets>
-    <fileSet>
-      <directory>${basedir}/src</directory>
-      <includes>
-        <include>**/*</include>
-      </includes>
-      <outputDirectory></outputDirectory>
-    </fileSet>
-  </fileSets>
+    <id>distribution</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>${basedir}/src</directory>
+            <includes>
+                <include>**/*</include>
+            </includes>
+            <outputDirectory></outputDirectory>
+        </fileSet>
+    </fileSets>
 </assembly>

--- a/src/main/archetype/dispatcher.cloud/pom.xml
+++ b/src/main/archetype/dispatcher.cloud/pom.xml
@@ -2,44 +2,44 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <!-- ====================================================================== -->
-  <!-- P A R E N T  P R O J E C T  D E S C R I P T I O N                      -->
-  <!-- ====================================================================== -->
-  <parent>
-    <groupId>${groupId}</groupId>
-    <artifactId>${rootArtifactId}</artifactId>
-    <version>${version}</version>
-    <relativePath>../pom.xml</relativePath>
-  </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <!-- ====================================================================== -->
+    <!-- P A R E N T  P R O J E C T  D E S C R I P T I O N                      -->
+    <!-- ====================================================================== -->
+    <parent>
+        <groupId>${groupId}</groupId>
+        <artifactId>${rootArtifactId}</artifactId>
+        <version>${version}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
 
-  <artifactId>${artifactId}</artifactId>
-  <packaging>pom</packaging>
-  <name>${appTitle} - Dispatcher</name>
-  <description>HTTP &amp; Dispatcher configurations for ${appTitle}</description>
+    <artifactId>${artifactId}</artifactId>
+    <packaging>pom</packaging>
+    <name>${appTitle} - Dispatcher</name>
+    <description>HTTP &amp; Dispatcher configurations for ${appTitle}</description>
 
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.1.1</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>single</goal>
-            </goals>
-            <configuration>
-              <descriptors>
-                <descriptor>assembly.xml</descriptor>
-              </descriptors>
-              <appendAssemblyId>false</appendAssemblyId>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>assembly.xml</descriptor>
+                            </descriptors>
+                            <appendAssemblyId>false</appendAssemblyId>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/archetype/dispatcher.cloud/src/conf.dispatcher.d/dispatcher.any
+++ b/src/main/archetype/dispatcher.cloud/src/conf.dispatcher.d/dispatcher.any
@@ -6,6 +6,6 @@
 #
 
 /farms {
-  # Include all *.farm files in enabled_farms
-  $include "enabled_farms/*.farm"
+	# Include all *.farm files in enabled_farms
+	$include "enabled_farms/*.farm"
 }

--- a/src/main/archetype/dispatcher.cloud/src/conf.dispatcher.d/renders/default_renders.any
+++ b/src/main/archetype/dispatcher.cloud/src/conf.dispatcher.d/renders/default_renders.any
@@ -5,7 +5,7 @@
 #
 
 /0 {
-  /hostname "${AEM_HOST}"
-  /port "${AEM_PORT}"
-  /timeout "10000"
+	/hostname "${AEM_HOST}"
+	/port "${AEM_PORT}"
+	/timeout "10000"
 }


### PR DESCRIPTION
## Description

- made sure all dispatcher config files (xml based and any format) used tabs for indentations as this seems to be the commonly used.
- made sure that pom.xml and assembly.xml in the root of the dispatcher modules uses 4 space indentations and not 2, same as in the other modules.
- fixed some wrong indentations

## Related Issue
fixed #443 

