### PR TITLE
"Unhide components" on a page does not list hidden components

### DIFF
--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/clientlibs/clientlib-grid/less/grid.less
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/clientlibs/clientlib-grid/less/grid.less
@@ -37,3 +37,8 @@
     .generate-grid(tablet, @max_col);
   }
 }
+
+/* force showing hidden components in unhide mode */
+.aem-GridShowHidden > .cmp-container > .aem-Grid > .aem-GridColumn {
+  display: block !important;
+}


### PR DESCRIPTION
* Added CSS rule to show hidden components in unhide mode

Fixes #499
