### PR TITLE
CIF-1661 - Configure title tag policies for CIF components in AEM arc…

### DIFF
--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__appId__/settings/wcm/policies/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__appId__/settings/wcm/policies/.content.xml
@@ -422,6 +422,42 @@
                         </cq:styleGroups>
                     </default>
                 </productlist>
+                <productcarousel jcr:primaryType="nt:unstructured">
+                    <default
+                        jcr:lastModified="{Date}2020-09-28T15:37:21.146+02:00"
+                        jcr:lastModifiedBy="admin"
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="AEM CIF Core Components Product Carousel"
+                        sling:resourceType="wcm/core/components/policy/policy"
+                        allowedTypes="[h2,h3,h4,h5,h6]"
+                        type="h2">
+                        <jcr:content jcr:primaryType="nt:unstructured"/>
+                    </default>
+                </productcarousel>
+                <relatedproducts jcr:primaryType="nt:unstructured">
+                    <default
+                        jcr:lastModified="{Date}2020-09-28T15:37:21.146+02:00"
+                        jcr:lastModifiedBy="admin"
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="AEM CIF Core Components Related Products"
+                        sling:resourceType="wcm/core/components/policy/policy"
+                        allowedTypes="[h2,h3,h4,h5,h6]"
+                        type="h2">
+                        <jcr:content jcr:primaryType="nt:unstructured"/>
+                    </default>
+                </relatedproducts>
+                <featuredcategorylist jcr:primaryType="nt:unstructured">
+                    <default
+                        jcr:lastModified="{Date}2020-09-28T15:37:21.146+02:00"
+                        jcr:lastModifiedBy="admin"
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="AEM CIF Core Components Featured Category List"
+                        sling:resourceType="wcm/core/components/policy/policy"
+                        allowedTypes="[h2,h3,h4,h5,h6]"
+                        type="h2">
+                        <jcr:content jcr:primaryType="nt:unstructured"/>
+                    </default>
+                </featuredcategorylist>
             </commerce>
 #end
         </components>

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__appId__/settings/wcm/templates/page-content/policies/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__appId__/settings/wcm/templates/page-content/policies/.content.xml
@@ -55,6 +55,20 @@
                                 cq:policy="${appId}/components/download/policy_1575032193319"
                                 jcr:primaryType="nt:unstructured"
                                 sling:resourceType="wcm/core/components/policies/mapping"/>
+#if ( $includeCommerce == "y" )
+                            <productcarousel
+                                cq:policy="${appId}/components/commerce/productcarousel/default"
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="wcm/core/components/policies/mapping" />
+                            <relatedproducts
+                                cq:policy="${appId}/components/commerce/relatedproducts/default"
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="wcm/core/components/policies/mapping" />
+                            <featuredcategorylist
+                                cq:policy="${appId}/components/commerce/featuredcategorylist/default"
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="wcm/core/components/policies/mapping" />
+#end
                         </components>
                     </${appId}>
                 </container>

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__appId__/settings/wcm/templates/page-content/policies/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__appId__/settings/wcm/templates/page-content/policies/.content.xml
@@ -56,18 +56,20 @@
                                 jcr:primaryType="nt:unstructured"
                                 sling:resourceType="wcm/core/components/policies/mapping"/>
 #if ( $includeCommerce == "y" )
-                            <productcarousel
-                                cq:policy="${appId}/components/commerce/productcarousel/default"
-                                jcr:primaryType="nt:unstructured"
-                                sling:resourceType="wcm/core/components/policies/mapping" />
-                            <relatedproducts
-                                cq:policy="${appId}/components/commerce/relatedproducts/default"
-                                jcr:primaryType="nt:unstructured"
-                                sling:resourceType="wcm/core/components/policies/mapping" />
-                            <featuredcategorylist
-                                cq:policy="${appId}/components/commerce/featuredcategorylist/default"
-                                jcr:primaryType="nt:unstructured"
-                                sling:resourceType="wcm/core/components/policies/mapping" />
+                            <commerce jcr:primaryType="nt:unstructured">
+                                <productcarousel
+                                    cq:policy="${appId}/components/commerce/productcarousel/default"
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="wcm/core/components/policies/mapping" />
+                                <relatedproducts
+                                    cq:policy="${appId}/components/commerce/relatedproducts/default"
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="wcm/core/components/policies/mapping" />
+                                <featuredcategorylist
+                                    cq:policy="${appId}/components/commerce/featuredcategorylist/default"
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="wcm/core/components/policies/mapping" />
+                            </commerce>
 #end
                         </components>
                     </${appId}>

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__appId__/settings/wcm/templates/xf-web-variation/policies/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__appId__/settings/wcm/templates/xf-web-variation/policies/.content.xml
@@ -31,6 +31,20 @@
                         cq:policy="${appId}/components/image/policy_651483963895698"
                         jcr:primaryType="nt:unstructured"
                         sling:resourceType="wcm/core/components/policies/mapping"/>
+#if ( $includeCommerce == "y" )
+                    <productcarousel
+                        cq:policy="${appId}/components/commerce/productcarousel/default"
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="wcm/core/components/policies/mapping" />
+                    <relatedproducts
+                        cq:policy="${appId}/components/commerce/relatedproducts/default"
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="wcm/core/components/policies/mapping" />
+                    <featuredcategorylist
+                        cq:policy="${appId}/components/commerce/featuredcategorylist/default"
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="wcm/core/components/policies/mapping" />
+#end
                 </components>
             </mysite>
         </root>

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__appId__/settings/wcm/templates/xf-web-variation/policies/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__appId__/settings/wcm/templates/xf-web-variation/policies/.content.xml
@@ -32,18 +32,20 @@
                         jcr:primaryType="nt:unstructured"
                         sling:resourceType="wcm/core/components/policies/mapping"/>
 #if ( $includeCommerce == "y" )
-                    <productcarousel
-                        cq:policy="${appId}/components/commerce/productcarousel/default"
-                        jcr:primaryType="nt:unstructured"
-                        sling:resourceType="wcm/core/components/policies/mapping" />
-                    <relatedproducts
-                        cq:policy="${appId}/components/commerce/relatedproducts/default"
-                        jcr:primaryType="nt:unstructured"
-                        sling:resourceType="wcm/core/components/policies/mapping" />
-                    <featuredcategorylist
-                        cq:policy="${appId}/components/commerce/featuredcategorylist/default"
-                        jcr:primaryType="nt:unstructured"
-                        sling:resourceType="wcm/core/components/policies/mapping" />
+                    <commerce jcr:primaryType="nt:unstructured">
+                        <productcarousel
+                            cq:policy="${appId}/components/commerce/productcarousel/default"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="wcm/core/components/policies/mapping" />
+                        <relatedproducts
+                            cq:policy="${appId}/components/commerce/relatedproducts/default"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="wcm/core/components/policies/mapping" />
+                        <featuredcategorylist
+                            cq:policy="${appId}/components/commerce/featuredcategorylist/default"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="wcm/core/components/policies/mapping" />
+                    </commerce>
 #end
                 </components>
             </mysite>


### PR DESCRIPTION
…hetype

Like for the `Title` component, this adds a default policy for the title tag of the `ProductCarousel`, `RelatedProducts`, and `FeaturedCategoryList` components. We enable by default all `H?` tags except `H1` as this is reserved for the page title by default.

## How Has This Been Tested?

Manually tested with https://github.com/adobe/aem-cif-guides-venia/pull/66


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.