### PR TITLE
Dispatcher vars file ignored

### DIFF
--- a/src/main/archetype/.gitignore
+++ b/src/main/archetype/.gitignore
@@ -98,3 +98,6 @@ node/
 # Tests
 coverage/
 reports/
+
+# Others
+dispatcher/src/conf.d/variables/default.vars


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I am integrating AEM projects generated from this archetype with bigger Gradle builds. Dispatcher configuration is being provided to HTTPD via Docker/volume. As a result of o such configuration, I am achieving a live-reloading feature (without a need for building ZIP by Maven) for easy and comfortable work with Dispatcher config files. However, file: 'dispatcher/src/conf.d/variables/default.vars' need to be provided externally to be able to start HTTPD service. As it is not Git-ignored right now, and the whole path 'dispatcher/src/conf.d' is mounted as a volume in my case, after each project generation I need to append a line for ignoring this file manually (and tell everybody else to do that also), because after providing it externally Git recognizes it as a new untracked file. It would be nice to have it ignored in an archetype so that I will be able to skip that manual step (and my other co-workers who are generating projects from this archetype).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.