### PR TITLE
Add filter to allow dispatcher to expose files with a webmanifest extension

### DIFF
--- a/src/main/archetype/dispatcher.ams/src/conf.dispatcher.d/filters/ams_publish_filters.any
+++ b/src/main/archetype/dispatcher.ams/src/conf.dispatcher.d/filters/ams_publish_filters.any
@@ -39,3 +39,6 @@
 
 # Enable specific mime types clientlibs directories
 /0105 { /type "allow" /extension '(gltf|stl|obj|usdz|glb)' /method "GET" /path "/content/dam/*" }
+
+# Allow webmanifest extension
+/0106 { /type "allow" /extension "webmanifest" /path "/content/*" }

--- a/src/main/archetype/dispatcher.ams/src/conf.dispatcher.d/filters/ams_publish_filters.any
+++ b/src/main/archetype/dispatcher.ams/src/conf.dispatcher.d/filters/ams_publish_filters.any
@@ -39,6 +39,3 @@
 
 # Enable specific mime types clientlibs directories
 /0105 { /type "allow" /extension '(gltf|stl|obj|usdz|glb)' /method "GET" /path "/content/dam/*" }
-
-# Allow webmanifest extension
-/0106 { /type "allow" /extension "webmanifest" /path "/content/*" }

--- a/src/main/archetype/dispatcher.cloud/src/conf.dispatcher.d/filters/filters.any
+++ b/src/main/archetype/dispatcher.cloud/src/conf.dispatcher.d/filters/filters.any
@@ -8,3 +8,6 @@ $include "./default_filters.any"
 
 # Allow components JSON model
 /0101 { /type "allow" /extension "json" /selectors "model" /path "/content/*" }
+
+# Allow webmanifest extension
+/0102 { /type "allow" /extension "webmanifest" /path "/content/*" }

--- a/src/main/archetype/dispatcher.cloud/src/conf.dispatcher.d/filters/filters.any
+++ b/src/main/archetype/dispatcher.cloud/src/conf.dispatcher.d/filters/filters.any
@@ -9,5 +9,5 @@ $include "./default_filters.any"
 # Allow components JSON model
 /0101 { /type "allow" /extension "json" /selectors "model" /path "/content/*" }
 
-# Allow webmanifest extension
+# Allow manifest.webmanifest files located in the content
 /0102 { /type "allow" /extension "webmanifest" /path "/content/*/manifest" }

--- a/src/main/archetype/dispatcher.cloud/src/conf.dispatcher.d/filters/filters.any
+++ b/src/main/archetype/dispatcher.cloud/src/conf.dispatcher.d/filters/filters.any
@@ -10,4 +10,4 @@ $include "./default_filters.any"
 /0101 { /type "allow" /extension "json" /selectors "model" /path "/content/*" }
 
 # Allow webmanifest extension
-/0102 { /type "allow" /extension "webmanifest" /path "/content/*" }
+/0102 { /type "allow" /extension "webmanifest" /path "/content/*/manifest" }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

To support the following roadmap [0], we agreed to add filters that will allow the dispatcher to expose files that end with a `webmanifest` extension.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#551

## Motivation and Context

The change relates to [0] and has been suggested to be added to the archetype.

[0] CQ-4293019 - Enhance AEM Sites to make sites installable (incl. offline content) using PWA

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on an internal Cloud Service instance.

## Screenshots (if appropriate):

Probably unnecessary

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.