### PR TITLE
Support aemanalyser-maven-plugin in the generated projects (#533)

### DIFF
--- a/src/main/archetype/README.md
+++ b/src/main/archetype/README.md
@@ -14,6 +14,7 @@ The main parts of the template are:
 * ui.frontend: an optional dedicated front-end build mechanism (Angular, React or general Webpack project)
 * ui.tests: Selenium based UI tests
 * all: a single content package that embeds all of the compiled modules (bundles and content packages) including any vendor dependencies
+* analyse: this module runs analysis on the project which provides additional validation for deploying into AEMaaCS
 
 ## How to build
 
@@ -81,6 +82,16 @@ Clients](https://github.com/adobe/aem-testing-clients) and showcase some
 recommended [best
 practices](https://github.com/adobe/aem-testing-clients/wiki/Best-practices) to
 be put in use when writing integration tests for AEM.
+
+## Static Analysis
+
+The `analyse` module performs static analysis on the project for deploying into AEMaaCS. It is automatically
+run when executing
+
+    mvn clean install
+
+from the project root directory. Additional information about this analysis and how to further configure it
+can be found here https://github.com/adobe/aemanalyser-maven-plugin
 
 ### UI tests
 

--- a/src/main/archetype/analyse/pom.xml
+++ b/src/main/archetype/analyse/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ |  Copyright 2020 Adobe Systems Incorporated
+ |
+ |  Licensed under the Apache License, Version 2.0 (the "License");
+ |  you may not use this file except in compliance with the License.
+ |  You may obtain a copy of the License at
+ |
+ |      http://www.apache.org/licenses/LICENSE-2.0
+ |
+ |  Unless required by applicable law or agreed to in writing, software
+ |  distributed under the License is distributed on an "AS IS" BASIS,
+ |  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ |  See the License for the specific language governing permissions and
+ |  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+        <!-- ====================================================================== -->
+        <!-- P A R E N T  P R O J E C T  D E S C R I P T I O N                      -->
+        <!-- ====================================================================== -->
+    <parent>
+        <groupId>${groupId}</groupId>
+        <artifactId>${rootArtifactId}</artifactId>
+        <version>${version}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <!-- ====================================================================== -->
+    <!-- P R O J E C T  D E S C R I P T I O N                                   -->
+    <!-- ====================================================================== -->
+    <artifactId>${artifactId}</artifactId>
+    <name>${appTitle} - Project Analyser</name>
+    <description>Project analysis for ${appTitle}</description>
+    <packaging>aem-analyse</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.adobe.aem</groupId>
+                <artifactId>aemanalyser-maven-plugin</artifactId>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>${groupId}</groupId>
+            <artifactId>${rootArtifactId}.all</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -52,6 +52,7 @@
         <module>ui.frontend.angular</module>
         <module>ui.frontend.react</module>
         <module>ui.tests</module>
+        <module>analyse</module>
     </modules>
 
     <properties>
@@ -87,6 +88,7 @@
 #end
 #if ( $aemVersion == "cloud")
         <aem.sdk.api>SDK_VERSION</aem.sdk.api>
+        <aemanalyser.version>0.0.12</aemanalyser.version>
 #end
         <componentGroupName>$appTitle</componentGroupName>
     </properties>
@@ -315,6 +317,13 @@ Bundle-DocURL:
                             <version>6.5.5.0</version>
                         </dependency>
                     </dependencies>
+                </plugin>
+                <!-- AEM Analyser Plugin -->
+                <plugin>
+                    <groupId>com.adobe.aem</groupId>
+                    <artifactId>aemanalyser-maven-plugin</artifactId>
+                    <version>${aemanalyser.version}</version>
+                    <extensions>true</extensions>
                 </plugin>
                 <!-- Content Package Plugin -->
                 <plugin>
@@ -746,7 +755,7 @@ Bundle-DocURL:
                 <type>zip</type>
                 <version>${core.wcm.components.version}</version>
             </dependency>
-#if ( $amp == "y" || $includeExamples == "y")
+#if ( $amp == "y" || $includeExamples == "y" )
             <dependency>
                 <groupId>com.adobe.cq</groupId>
                 <artifactId>core.wcm.components.extensions.amp</artifactId>

--- a/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -64,6 +64,16 @@ if (aemVersion == "cloud") {
     }
     println "Using AEM as a Cloud Service SDK version: " + sdkVersion
     rootPom.text = rootPom.text.replaceAll('SDK_VERSION', sdkVersion.toString())
+} else {
+    // remove the analyser module as it's only for cloud
+    assert new File(rootDir, 'analyse').deleteDir();
+    removeModule(rootPom, 'analyse')
+}
+
+// Temporary until the cif-cloud project supports the feature model analysers
+if (aemVersion == "cloud" && includeCommerce == "y") {
+    assert new File(rootDir, 'analyse').deleteDir();
+    removeModule(rootPom, 'analyse')
 }
 
 buildContentSkeleton(uiContentPackage, uiAppsPackage, singleCountry, appId, language, country)

--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -164,6 +164,8 @@
                 </fileSet>
             </fileSets>
         </module>
+        <module id="${rootArtifactId}.analyse" dir="analyse" name="analyse">
+        </module>
         <module id="${rootArtifactId}.core" dir="core" name="core">
             <fileSets>
                 <fileSet filtered="true" packaged="true"


### PR DESCRIPTION
## Description

AEMaaCS provides extended analysis of projects in the build and deployment pipeline. This includes running the Feature Model Analysers on the content packages. If these analysers find a problem they will fail the build and the developer needs to rectify the problem. 
This can be problematic for developers as there is an amount of time between these failures in the deployment pipelines and the actual development of the content packages.

The new [aemanalyser-maven-plugin](https://github.com/adobe/aemanalyser-maven-plugin/blob/main/aemanalyser-maven-plugin/README.md) makes it possible to run these analysers that are already running in the pipeline on the developer's local machine as part of the Maven build. This will give much quicker feedback to the developer and shortens the developer life cycle.

## Motivation and Context

Shorten the development lifecycle and provide early feedback.

## How Has This Been Tested?

It has been tested by running the following commandline on my branch:

```
mvn -B archetype:generate \
 -D archetypeGroupId=com.adobe.aem \
 -D archetypeArtifactId=aem-project-archetype \
 -D archetypeVersion=25-SNAPSHOT \
 -D appTitle="Test1" \
 -D appId="test1" \
 -D groupId="com.mysite
```

And then running `mvn install` to see if the analysis is triggered.

The changes to the archetype introduce a new module which sole purpose is to run the analysis. There are no changes needed to the other projects, just an extra dependency and an extra module referenced in the top level pom. 

If everything is good then the build will just complete for the developer as before. If the analysers find issues then the build of the new `analyse` module will fail.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
