### PR TITLE
CIF-1177 - Product reference tab for Experience Fragments

### DIFF
--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/components/xfpage/_cq_dialog/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/components/xfpage/_cq_dialog/.content.xml
@@ -69,6 +69,33 @@
                                                 rootPath="/content"/>
                                         </items>
                                     </pagesSection>
+#if ( $aemVersion == "cloud" )
+                                    <productsPickerSection
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Product selection"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/fieldset">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <products
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="commerce/gui/components/common/cifproductfield"
+                                                fieldDescription="Select the products associated with this experience fragment variation."
+                                                fieldLabel="Product SKUs."
+                                                filter="folderOrProductOrVariant"
+                                                multiple="true"
+                                                name="./cq:products"
+                                                rootPath="/var/commerce/products"
+                                                selectionId="combinedSku">
+                                                <granite:data
+                                                    jcr:primaryType="nt:unstructured"
+                                                    metaType="text"/>
+                                            </products>
+                                            <productstab
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="commerce/gui/components/common/productreferencetab"
+                                                targetProperty="jcr:content/cq:products"/>
+                                        </items>
+                                    </productsPickerSection>
+#end
                                 </items>
                             </column>
                         </items>


### PR DESCRIPTION
- add product references to experience fragments (cloud only)

## How Has This Been Tested?

Manually tested.

See https://github.com/adobe/aem-cif-guides-venia/pull/90 for the result in the Venia demo.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.