### PR TITLE
add an additional IT test

### DIFF
--- a/src/main/archetype/it.tests/pom.xml
+++ b/src/main/archetype/it.tests/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>net.sourceforge.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
-            <version>2.37.0</version>
+            <version>2.45.0</version>
         </dependency>
 #if ($aemVersion == "cloud")
         <dependency>

--- a/src/main/archetype/it.tests/pom.xml
+++ b/src/main/archetype/it.tests/pom.xml
@@ -40,6 +40,11 @@
             <artifactId>junit</artifactId>
             <version>4.13.1</version>
         </dependency>
+        <dependency>
+            <groupId>net.sourceforge.htmlunit</groupId>
+            <artifactId>htmlunit</artifactId>
+            <version>2.37.0</version>
+        </dependency>
 #if ($aemVersion == "cloud")
         <dependency>
             <groupId>com.adobe.cq</groupId>

--- a/src/main/archetype/it.tests/src/main/java/it/tests/HtmlUnitClient.java
+++ b/src/main/archetype/it.tests/src/main/java/it/tests/HtmlUnitClient.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2020 Adobe Systems Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.it.tests;
+
+import com.adobe.cq.testing.client.CQClient;
+import com.gargoylesoftware.htmlunit.DefaultCssErrorHandler;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.WebClientOptions;
+import com.gargoylesoftware.htmlunit.html.DomNode;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.sling.testing.clients.ClientException;
+import org.apache.sling.testing.clients.SlingClientConfig;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Node;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.junit.Assert.fail;
+
+/**
+ * AEM client that maintains a WebClient instance from HttpUnit framework
+ */
+public class HtmlUnitClient extends CQClient {
+	
+	
+	private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(HtmlUnitClient.class);
+
+    private final WebClient webClient = new WebClient();
+
+    /** Extracts references to external resources used by the specified page.
+     * This method extracts references from script, img, meta and link tags.
+     * @param path path to the page.
+     * @return list of URIs resolved against the pages baseURL
+     * @throws IOException when IO error occurs
+     * @throws URISyntaxException if malformed URL reference is found.
+     */
+    public List<URI> getResourceRefs(String path) throws IOException, URISyntaxException {
+        HtmlPage page = getPage(path, false);
+        List<URI> result = new ArrayList<>();
+        result.addAll(getRefs(page, "script", "src"));
+        result.addAll(getRefs(page, "img", "src"));
+        result.addAll(getRefs(page, "meta", "href"));
+        result.addAll(getRefs(page, "link", "href"));
+        result.addAll(getCoreComponentImageRenditions(page));
+        return result;
+    }
+
+    /**
+     * Loads html page specified by path.
+     * @param path path to the page
+     * @param javaScriptEnabled whether to execute javascript
+     * @return parsed page.
+     * @throws IOException if IO error occurs.
+     */
+    public HtmlPage getPage(String path, boolean javaScriptEnabled) throws IOException {
+        WebClientOptions options = webClient.getOptions();
+        boolean wasJsEnabled = options.isJavaScriptEnabled();
+        try {
+            options.setJavaScriptEnabled(javaScriptEnabled);
+            return getPage(webClient, getUrl(path).toURL());
+        } finally {
+            options.setJavaScriptEnabled(wasJsEnabled);
+        }
+    }
+
+    //*********************************************
+    // Creation
+    //*********************************************
+
+    public HtmlUnitClient(CloseableHttpClient http, SlingClientConfig config) throws ClientException {
+        super(http, config);
+        webClient.setCredentialsProvider(this.getCredentialsProvider());
+    }
+
+    public HtmlUnitClient(URI url, String user, String password) throws ClientException {
+        super(url, user, password);
+        webClient.setCredentialsProvider(this.getCredentialsProvider());
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            webClient.close();
+        } finally {
+            super.close();
+        }
+    }
+
+    //*********************************************
+    // Internals
+    //*********************************************
+
+    private static List<URI> getRefs(HtmlPage page, String tag, String refAttr) throws URISyntaxException {
+        URI baseUri = new URI(page.getBaseURI());
+        List<URI> result = new ArrayList<>();
+        for (DomNode child : page.getElementsByTagName(tag)) {
+            URI uriRef = getNamedItemAsUri(child, refAttr);
+            if (uriRef != null) {
+                URI uri = baseUri.resolve(uriRef);
+                result.add(uri);
+            }
+        }
+        return result;
+    }
+    
+    /**
+     * Extract all image core components and their references from the page.
+     * @param page the page to scan
+     * @return all renditions of all image core components
+     * @throws URISyntaxException
+     */
+    private static List<URI> getCoreComponentImageRenditions (HtmlPage page) throws URISyntaxException {
+        URI baseUri = new URI(page.getBaseURI());
+        List<URI> result = new ArrayList<>();
+        
+        // detect images core components based on the CSS class name
+        List<DomNode> coreComponents = page.getByXPath("//div[contains(@class, 'cmp-image')]");
+        for (DomNode child:  coreComponents) {
+        	String src = null;
+        	String width = null;
+        	if (child.getAttributes().getNamedItem("data-cmp-src") != null) {
+        		src = child.getAttributes().getNamedItem("data-cmp-src").getNodeValue();
+        	}
+        	if (child.getAttributes().getNamedItem("data-cmp-widths") != null) {
+        		width = child.getAttributes().getNamedItem("data-cmp-widths").getNodeValue();
+        	}
+        	if (src != null && width != null) {
+	        	String[] widths = width.split(",");
+	        	for (String w: widths) {
+	        		String ref = src.replace("{.width}", "."+w);
+	        		result.add(baseUri.resolve(ref));
+	        	}
+        	} else if (src != null && width == null) {
+        		// happens with SVG and GIFs
+        		String ref = src.replace("{.width}", "");
+        		result.add(baseUri.resolve(ref));
+        	}
+        }
+        return result;
+    }
+    
+
+    /**
+     *  Loads requested page while suppressing CSS errors (logged as warnings)
+     * @param webClient web client to use for loading
+     * @param url page URL
+     * @return loaded HtmlPage instance.
+     * @throws IOException when error occurs
+     */
+    private static HtmlPage getPage(WebClient webClient, URL url) throws IOException {
+        Logger logger = Logger.getLogger(DefaultCssErrorHandler.class.getName());
+        Level originalLevel = logger.getLevel();
+        try {
+            logger.setLevel(Level.SEVERE);
+            return webClient.getPage(url);
+        } finally {
+            logger.setLevel(originalLevel);
+        }
+    }
+
+    /**
+     * Extracts URI reference from specified element and converts it to URI
+     * This method will trigger junit assertion if refAttr value cannot be parsed as URI
+     * providing comprehensive error message.
+     * @param node - html element from which to extract reference
+     * @param refAttr - name of the attribute containing corresponding value
+     * @return refAttr value as URI or <code>null</code> if attribute does not exist
+     */
+    private static URI getNamedItemAsUri(DomNode node, String refAttr) {
+        Node src = node.getAttributes().getNamedItem(refAttr);
+        if (src == null) {
+            return null;
+        } else {
+            try {
+                String href = src.getNodeValue();
+                return new URI(href);
+            } catch (URISyntaxException e) {
+                fail("Invalid URI value in [" + refAttr + "] attribute in: [" + node + "].\n" +
+                        "   Page URL:  [" + node.getPage().getUrl() + "]\n" +
+                        "   XPath:     [" + node.getCanonicalXPath() + "]\n" +
+                        "   Caused by: [" + e.getMessage() + "]");
+                throw new AssertionError(); // must never happen
+            }
+        }
+    }
+}

--- a/src/main/archetype/it.tests/src/main/java/it/tests/HtmlUnitClient.java
+++ b/src/main/archetype/it.tests/src/main/java/it/tests/HtmlUnitClient.java
@@ -39,7 +39,7 @@ import java.util.logging.Logger;
 import static org.junit.Assert.fail;
 
 /**
- * AEM client that maintains a WebClient instance from HttpUnit framework
+ * AEM client that maintains a WebClient instance from HTMLUnit framework
  */
 public class HtmlUnitClient extends CQClient {
 

--- a/src/main/archetype/it.tests/src/main/java/it/tests/HtmlUnitClient.java
+++ b/src/main/archetype/it.tests/src/main/java/it/tests/HtmlUnitClient.java
@@ -42,9 +42,9 @@ import static org.junit.Assert.fail;
  * AEM client that maintains a WebClient instance from HttpUnit framework
  */
 public class HtmlUnitClient extends CQClient {
-	
-	
-	private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(HtmlUnitClient.class);
+
+
+    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(HtmlUnitClient.class);
 
     private final WebClient webClient = new WebClient();
 
@@ -123,7 +123,7 @@ public class HtmlUnitClient extends CQClient {
         }
         return result;
     }
-    
+
     /**
      * Extract all image core components and their references from the page.
      * @param page the page to scan
@@ -133,33 +133,33 @@ public class HtmlUnitClient extends CQClient {
     private static List<URI> getCoreComponentImageRenditions (HtmlPage page) throws URISyntaxException {
         URI baseUri = new URI(page.getBaseURI());
         List<URI> result = new ArrayList<>();
-        
+
         // detect images core components based on the CSS class name
         List<DomNode> coreComponents = page.getByXPath("//div[contains(@class, 'cmp-image')]");
         for (DomNode child:  coreComponents) {
-        	String src = null;
-        	String width = null;
-        	if (child.getAttributes().getNamedItem("data-cmp-src") != null) {
-        		src = child.getAttributes().getNamedItem("data-cmp-src").getNodeValue();
-        	}
-        	if (child.getAttributes().getNamedItem("data-cmp-widths") != null) {
-        		width = child.getAttributes().getNamedItem("data-cmp-widths").getNodeValue();
-        	}
-        	if (src != null && width != null) {
-	        	String[] widths = width.split(",");
-	        	for (String w: widths) {
-	        		String ref = src.replace("{.width}", "."+w);
-	        		result.add(baseUri.resolve(ref));
-	        	}
-        	} else if (src != null && width == null) {
-        		// happens with SVG and GIFs
-        		String ref = src.replace("{.width}", "");
-        		result.add(baseUri.resolve(ref));
-        	}
+            String src = null;
+            String width = null;
+            if (child.getAttributes().getNamedItem("data-cmp-src") != null) {
+                src = child.getAttributes().getNamedItem("data-cmp-src").getNodeValue();
+            }
+            if (child.getAttributes().getNamedItem("data-cmp-widths") != null) {
+                width = child.getAttributes().getNamedItem("data-cmp-widths").getNodeValue();
+            }
+            if (src != null && width != null) {
+                String[] widths = width.split(",");
+                for (String w: widths) {
+                    String ref = src.replace("{.width}", "."+w);
+                    result.add(baseUri.resolve(ref));
+                }
+            } else if (src != null && width == null) {
+                // happens with SVG and GIFs
+                String ref = src.replace("{.width}", "");
+                result.add(baseUri.resolve(ref));
+            }
         }
         return result;
     }
-    
+
 
     /**
      *  Loads requested page while suppressing CSS errors (logged as warnings)

--- a/src/main/archetype/it.tests/src/main/java/it/tests/PublishPageValidationIT.java
+++ b/src/main/archetype/it.tests/src/main/java/it/tests/PublishPageValidationIT.java
@@ -51,18 +51,18 @@ import java.util.List;
  * 
  */
 public class PublishPageValidationIT {
-	
-	
-	// the page to test
-	private static final String HOMEPAGE = "/";
 
-	// list files which do return a zerobyte response body
+
+    // the page to test
+    private static final String HOMEPAGE = "/";
+
+    // list files which do return a zerobyte response body
     private static final List<String> ZEROBYTEFILES = Arrays.asList();
-    
-    
-    
+
+
+
     private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(PublishPageValidationIT.class);
-    
+
     @ClassRule
     public static CQAuthorPublishClassRule cqBaseClassRule = new CQAuthorPublishClassRule(true);
 
@@ -81,27 +81,27 @@ public class PublishPageValidationIT {
     public static void afterClass() {
         closeQuietly(adminPublish);
     }
-    
 
-    
+
+
     @Test
     public void validateHomepage() throws ClientException, IOException, URISyntaxException {
-    	String path = HOMEPAGE;
-    	verifyPage(adminPublish, path);
-    	verifyLinkedResources(adminPublish,path);
-    	
+        String path = HOMEPAGE;
+        verifyPage(adminPublish, path);
+        verifyLinkedResources(adminPublish,path);
+
     }
-    
-    
+
+
     private static void verifyPage (HtmlUnitClient client, String path) throws ClientProtocolException, IOException {
-    	URI baseURI = client.getUrl();
+        URI baseURI = client.getUrl();
         LOG.info("Using {} as baseURL", baseURI.toString());
         HttpGet get = new HttpGet(baseURI.toString() + path);
         org.apache.http.HttpResponse validationResponse = client.execute(get);
         assertEquals("Request to [" + get.getURI().toString() + "] does not return expected returncode 200",
                 200, validationResponse.getStatusLine().getStatusCode());
     }
-    
+
     private static void verifyLinkedResources(HtmlUnitClient client, String path) throws ClientException, IOException, URISyntaxException {
 
         List<URI> references = client.getResourceRefs(path);
@@ -116,24 +116,24 @@ public class PublishPageValidationIT {
                 if (! ZEROBYTEFILES.stream().anyMatch(s -> ref.getPath().startsWith(s))) {
                     assertTrue("Empty response body from [" + ref + "]", responseSize > 0);
                 }
-               
+
             } else {
                 LOG.info("skipping linked resource from another domain {}", ref.toString());
             }
         }
     }
-    
+
     /** Checks if two URIs have the same origin.
-    *
-    * @param uri1 first URI
-    * @param uri2 second URI
-    * @return true if two URI come from the same host, port and use the same scheme
-    */
-   private static boolean isSameOrigin(URI uri1, URI uri2) {
-       if (!uri1.getScheme().equals(uri2.getScheme())) {
-           return false;
-       } else return uri1.getAuthority().equals(uri2.getAuthority());
-   }
-    
+     *
+     * @param uri1 first URI
+     * @param uri2 second URI
+     * @return true if two URI come from the same host, port and use the same scheme
+     */
+    private static boolean isSameOrigin(URI uri1, URI uri2) {
+        if (!uri1.getScheme().equals(uri2.getScheme())) {
+            return false;
+        } else return uri1.getAuthority().equals(uri2.getAuthority());
+    }
+
 
 }

--- a/src/main/archetype/it.tests/src/main/java/it/tests/PublishPageValidationIT.java
+++ b/src/main/archetype/it.tests/src/main/java/it/tests/PublishPageValidationIT.java
@@ -1,0 +1,139 @@
+/*
+ *  Copyright 2020 Adobe Systems Incorporated
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package ${package}.it.tests;
+
+import com.adobe.cq.testing.client.CQClient;
+import com.adobe.cq.testing.junit.assertion.CQAssert;
+import com.adobe.cq.testing.junit.rules.CQAuthorClassRule;
+import com.adobe.cq.testing.junit.rules.CQAuthorPublishClassRule;
+import com.adobe.cq.testing.junit.rules.CQRule;
+import com.adobe.cq.testing.junit.rules.Page;
+
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.sling.testing.clients.ClientException;
+import org.apache.sling.testing.clients.SlingHttpResponse;
+import org.eclipse.jetty.client.HttpResponse;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.apache.commons.io.IOUtils.closeQuietly;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Validates pages on publish and makes sure that the page renders completely and also
+ * validates all linked resources (images, clientlibs etc).
+ * 
+ */
+public class PublishPageValidationIT {
+	
+	
+	// the page to test
+	private static final String HOMEPAGE = "/";
+
+	// list files which do return a zerobyte response body
+    private static final List<String> ZEROBYTEFILES = Arrays.asList();
+    
+    
+    
+    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(PublishPageValidationIT.class);
+    
+    @ClassRule
+    public static CQAuthorPublishClassRule cqBaseClassRule = new CQAuthorPublishClassRule(true);
+
+    @Rule
+    public CQRule cqBaseRule = new CQRule(cqBaseClassRule.publishRule);
+
+    private static HtmlUnitClient adminPublish;
+
+    @BeforeClass
+    public static void beforeClass() throws ClientException {
+
+        adminPublish = cqBaseClassRule.publishRule.getAdminClient(CQClient.class).adaptTo(HtmlUnitClient.class);
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        closeQuietly(adminPublish);
+    }
+    
+
+    
+    @Test
+    public void validateHomepage() throws ClientException, IOException, URISyntaxException {
+    	String path = HOMEPAGE;
+    	verifyPage(adminPublish, path);
+    	verifyLinkedResources(adminPublish,path);
+    	
+    }
+    
+    
+    private static void verifyPage (HtmlUnitClient client, String path) throws ClientProtocolException, IOException {
+    	URI baseURI = client.getUrl();
+        LOG.info("Using {} as baseURL", baseURI.toString());
+        HttpGet get = new HttpGet(baseURI.toString() + path);
+        org.apache.http.HttpResponse validationResponse = client.execute(get);
+        assertEquals("Request to [" + get.getURI().toString() + "] does not return expected returncode 200",
+                200, validationResponse.getStatusLine().getStatusCode());
+    }
+    
+    private static void verifyLinkedResources(HtmlUnitClient client, String path) throws ClientException, IOException, URISyntaxException {
+
+        List<URI> references = client.getResourceRefs(path);
+        assertTrue(path + " does not contain any references!", references.size() > 0);
+        for (URI ref : references ) {
+            if (isSameOrigin(client.getUrl(), ref)) {
+                LOG.info("verifying linked resource {}", ref.toString());
+                SlingHttpResponse response = client.doGet(ref.getRawPath());
+                int statusCode = response.getStatusLine().getStatusCode();
+                int responseSize = response.getContent().length();
+                assertEquals("Unexpected status returned from [" + ref + "]", 200, statusCode);
+                if (! ZEROBYTEFILES.stream().anyMatch(s -> ref.getPath().startsWith(s))) {
+                    assertTrue("Empty response body from [" + ref + "]", responseSize > 0);
+                }
+               
+            } else {
+                LOG.info("skipping linked resource from another domain {}", ref.toString());
+            }
+        }
+    }
+    
+    /** Checks if two URIs have the same origin.
+    *
+    * @param uri1 first URI
+    * @param uri2 second URI
+    * @return true if two URI come from the same host, port and use the same scheme
+    */
+   private static boolean isSameOrigin(URI uri1, URI uri2) {
+       if (!uri1.getScheme().equals(uri2.getScheme())) {
+           return false;
+       } else return uri1.getAuthority().equals(uri2.getAuthority());
+   }
+    
+
+}


### PR DESCRIPTION
A simple integration test which is able to validate a page on publish:
* Check external references (Clientlibs, images, renditions of Image Core Components)
* Check the statuscode and the size of the external references (should always be 200 and a non-zero byte size)

It uses the HTMLUnit library and can easily be extended to test other features of the page, too!

Thanks @volteanu for your help and inspiration!