### PR TITLE
Add core components to react and angular

### DIFF
--- a/src/main/archetype/ui.frontend.angular/package.json
+++ b/src/main/archetype/ui.frontend.angular/package.json
@@ -10,9 +10,11 @@
     "sync": "aemsync -d -w ../ui.apps/src/main/content"
   },
   "dependencies": {
-    "@adobe/aem-angular-editable-components": "^1.0.0",
-    "@adobe/aem-spa-component-mapping": "^1.0.5",
-    "@adobe/aem-spa-page-model-manager": "^1.0.3",
+    "@adobe/aem-angular-editable-components": "~1.2.0",
+    "@adobe/aem-spa-component-mapping": "~1.1.0",
+    "@adobe/aem-spa-page-model-manager": "~1.3.3",
+    "@adobe/aem-core-components-angular-base": "^1.0.4",
+    "@adobe/aem-core-components-angular-spa": "^1.0.4",
     "@angular/animations": "~9.1.12",
     "@angular/common": "~9.1.12",
     "@angular/compiler": "~9.1.12",

--- a/src/main/archetype/ui.frontend.angular/src/app/app.module.ts
+++ b/src/main/archetype/ui.frontend.angular/src/app/app.module.ts
@@ -25,15 +25,46 @@ import { ModelManagerService } from './components/model-manager.service';
 import { PageComponent } from './components/page/page.component';
 import { TextComponent } from './components/text/text.component';
 
+import {AemAngularCoreWcmComponentsTabsV1} from '@adobe/aem-core-components-angular-spa/containers/tabs/v1';
+
+import {AemAngularCoreWcmComponentsTitleV2} from '@adobe/aem-core-components-angular-base/authoring/title/v2';
+import {AemAngularCoreWcmComponentsBreadCrumbV2} from '@adobe/aem-core-components-angular-base/layout/breadcrumb/v2';
+import {AemAngularCoreWcmComponentsNavigationV1} from '@adobe/aem-core-components-angular-base/layout/navigation/v1';
+import {AemAngularCoreWcmComponentsButtonV1} from '@adobe/aem-core-components-angular-base/authoring/button/v1';
+import {AemAngularCoreWcmComponentsImageV2} from '@adobe/aem-core-components-angular-base/authoring/image/v2';
+
+import {AemAngularCoreWcmComponentsTeaserV1} from '@adobe/aem-core-components-angular-base/authoring/teaser/v1';
+import {AemAngularCoreWcmComponentsDownloadV1} from '@adobe/aem-core-components-angular-base/authoring/download/v1';
+
+import {AemAngularCoreWcmComponentsListV2} from '@adobe/aem-core-components-angular-base/authoring/list/v2';
+import {AemAngularCoreWcmComponentsSeparatorV1} from '@adobe/aem-core-components-angular-base/authoring/separator/v1';
+import {AemAngularCoreWcmComponentsAccordionV1} from '@adobe/aem-core-components-angular-spa/containers/accordion/v1';
+import {AemAngularCoreWcmComponentsCarouselV1} from '@adobe/aem-core-components-angular-spa/containers/carousel/v1';
+import {AemAngularCoreWcmComponentsLanguageNavigationV1} from '@adobe/aem-core-components-angular-base/layout/language-navigation/v1';
+
 @NgModule({
   imports: [
     BrowserModule,
     SpaAngularEditableComponentsModule,
-    AppRoutingModule
+    AppRoutingModule,
+    AemAngularCoreWcmComponentsTabsV1,
+    AemAngularCoreWcmComponentsTitleV2,
+    AemAngularCoreWcmComponentsBreadCrumbV2,
+    AemAngularCoreWcmComponentsNavigationV1,
+    AemAngularCoreWcmComponentsButtonV1,
+    AemAngularCoreWcmComponentsImageV2,
+    AemAngularCoreWcmComponentsTeaserV1,
+    AemAngularCoreWcmComponentsDownloadV1,
+    AemAngularCoreWcmComponentsListV2,
+    AemAngularCoreWcmComponentsSeparatorV1,
+    AemAngularCoreWcmComponentsAccordionV1,
+    AemAngularCoreWcmComponentsCarouselV1,
+    AemAngularCoreWcmComponentsLanguageNavigationV1
   ],
-  providers: [ModelManagerService, { provide: APP_BASE_HREF, useValue: '/' }],
+  providers: [ ModelManagerService,
+    { provide: APP_BASE_HREF, useValue: '/' } ],
   declarations: [AppComponent, TextComponent, PageComponent],
   entryComponents: [TextComponent, PageComponent],
-  bootstrap: [AppComponent]
+  bootstrap: [ AppComponent ]
 })
 export class AppModule {}

--- a/src/main/archetype/ui.frontend.angular/src/app/components/import-components.ts
+++ b/src/main/archetype/ui.frontend.angular/src/app/components/import-components.ts
@@ -13,6 +13,42 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+import {MapTo} from '@adobe/aem-angular-editable-components';
 
 import './container/container.component';
 import './responsive-grid/responsive-grid.component';
+
+import {TabsV1Component} from '@adobe/aem-core-components-angular-spa/containers/tabs/v1';
+
+import {TitleV2Component, TitleV2IsEmptyFn} from '@adobe/aem-core-components-angular-base/authoring/title/v2';
+import {BreadCrumbV2Component, BreadCrumbV2IsEmptyFn} from '@adobe/aem-core-components-angular-base/layout/breadcrumb/v2';
+import {NavigationV1Component, NavigationV1IsEmptyFn} from '@adobe/aem-core-components-angular-base/layout/navigation/v1';
+import {ButtonV1Component, ButtonV1IsEmptyFn} from '@adobe/aem-core-components-angular-base/authoring/button/v1';
+import {ImageV2Component, ImageV2IsEmptyFn} from '@adobe/aem-core-components-angular-base/authoring/image/v2';
+
+import {TeaserV1Component, TeaserV1IsEmptyFn} from '@adobe/aem-core-components-angular-base/authoring/teaser/v1';
+import {DownloadV1Component, DownloadV1IsEmptyFn} from '@adobe/aem-core-components-angular-base/authoring/download/v1';
+
+import {ListV2Component, ListV2IsEmptyFn} from '@adobe/aem-core-components-angular-base/authoring/list/v2';
+import {SeparatorV1Component} from '@adobe/aem-core-components-angular-base/authoring/separator/v1';
+import {AccordionV1Component} from '@adobe/aem-core-components-angular-spa/containers/accordion/v1';
+import {CarouselV1Component} from '@adobe/aem-core-components-angular-spa/containers/carousel/v1';
+import {LanguageNavigationV1Component} from '@adobe/aem-core-components-angular-base/layout/language-navigation/v1';
+
+
+MapTo('${projectName}/components/navigation')(NavigationV1Component, {isEmpty: NavigationV1IsEmptyFn});
+MapTo('${projectName}/components/teaser')(TeaserV1Component, {isEmpty: TeaserV1IsEmptyFn});
+MapTo('${projectName}/components/title')(TitleV2Component, {isEmpty: TitleV2IsEmptyFn});
+MapTo('${projectName}/components/separator')(SeparatorV1Component);
+
+
+MapTo('${projectName}/components/download')(DownloadV1Component,{isEmpty: DownloadV1IsEmptyFn});
+MapTo('${projectName}/components/languagenavigation')(LanguageNavigationV1Component);
+MapTo('${projectName}/components/list')(ListV2Component, {isEmpty: ListV2IsEmptyFn});
+MapTo('${projectName}/components/breadcrumb')(BreadCrumbV2Component, {isEmpty: BreadCrumbV2IsEmptyFn})
+MapTo('${projectName}/components/button')(ButtonV1Component, {isEmpty: ButtonV1IsEmptyFn});
+MapTo('${projectName}/components/image')(ImageV2Component, {isEmpty: ImageV2IsEmptyFn});
+
+MapTo('${projectName}/components/carousel')(CarouselV1Component);
+MapTo('${projectName}/components/accordion')(AccordionV1Component);
+MapTo('${projectName}/components/tabs')(TabsV1Component);

--- a/src/main/archetype/ui.frontend.angular/src/app/components/import-components.ts
+++ b/src/main/archetype/ui.frontend.angular/src/app/components/import-components.ts
@@ -36,19 +36,19 @@ import {CarouselV1Component} from '@adobe/aem-core-components-angular-spa/contai
 import {LanguageNavigationV1Component} from '@adobe/aem-core-components-angular-base/layout/language-navigation/v1';
 
 
-MapTo('${projectName}/components/navigation')(NavigationV1Component, {isEmpty: NavigationV1IsEmptyFn});
-MapTo('${projectName}/components/teaser')(TeaserV1Component, {isEmpty: TeaserV1IsEmptyFn});
-MapTo('${projectName}/components/title')(TitleV2Component, {isEmpty: TitleV2IsEmptyFn});
-MapTo('${projectName}/components/separator')(SeparatorV1Component);
+MapTo('${appId}/components/navigation')(NavigationV1Component, {isEmpty: NavigationV1IsEmptyFn});
+MapTo('${appId}/components/teaser')(TeaserV1Component, {isEmpty: TeaserV1IsEmptyFn});
+MapTo('${appId}/components/title')(TitleV2Component, {isEmpty: TitleV2IsEmptyFn});
+MapTo('${appId}/components/separator')(SeparatorV1Component);
 
 
-MapTo('${projectName}/components/download')(DownloadV1Component,{isEmpty: DownloadV1IsEmptyFn});
-MapTo('${projectName}/components/languagenavigation')(LanguageNavigationV1Component);
-MapTo('${projectName}/components/list')(ListV2Component, {isEmpty: ListV2IsEmptyFn});
-MapTo('${projectName}/components/breadcrumb')(BreadCrumbV2Component, {isEmpty: BreadCrumbV2IsEmptyFn})
-MapTo('${projectName}/components/button')(ButtonV1Component, {isEmpty: ButtonV1IsEmptyFn});
-MapTo('${projectName}/components/image')(ImageV2Component, {isEmpty: ImageV2IsEmptyFn});
+MapTo('${appId}/components/download')(DownloadV1Component,{isEmpty: DownloadV1IsEmptyFn});
+MapTo('${appId}/components/languagenavigation')(LanguageNavigationV1Component);
+MapTo('${appId}/components/list')(ListV2Component, {isEmpty: ListV2IsEmptyFn});
+MapTo('${appId}/components/breadcrumb')(BreadCrumbV2Component, {isEmpty: BreadCrumbV2IsEmptyFn})
+MapTo('${appId}/components/button')(ButtonV1Component, {isEmpty: ButtonV1IsEmptyFn});
+MapTo('${appId}/components/image')(ImageV2Component, {isEmpty: ImageV2IsEmptyFn});
 
-MapTo('${projectName}/components/carousel')(CarouselV1Component);
-MapTo('${projectName}/components/accordion')(AccordionV1Component);
-MapTo('${projectName}/components/tabs')(TabsV1Component);
+MapTo('${appId}/components/carousel')(CarouselV1Component);
+MapTo('${appId}/components/accordion')(AccordionV1Component);
+MapTo('${appId}/components/tabs')(TabsV1Component);

--- a/src/main/archetype/ui.frontend.react/package.json
+++ b/src/main/archetype/ui.frontend.react/package.json
@@ -10,9 +10,11 @@
     "sync": "aemsync -d -w ../ui.apps/src/main/content"
   },
   "dependencies": {
-    "@adobe/aem-react-editable-components": "^1.0.0",
-    "@adobe/aem-spa-component-mapping": "^1.0.0",
-    "@adobe/aem-spa-page-model-manager": "^1.0.0",
+    "@adobe/aem-react-editable-components": "~1.1.2",
+    "@adobe/aem-spa-component-mapping": "~1.1.0",
+    "@adobe/aem-spa-page-model-manager": "~1.3.3",
+    "@adobe/aem-core-components-react-base": "1.1.3",
+    "@adobe/aem-core-components-react-spa": "1.1.3",
     "custom-event-polyfill": "^1.0.7",
     "dompurify": "^2.0.7",
     "history": "^4.10.1",

--- a/src/main/archetype/ui.frontend.react/src/components/import-components.js
+++ b/src/main/archetype/ui.frontend.react/src/components/import-components.js
@@ -18,3 +18,42 @@ import './Page/Page';
 import './Text/Text';
 import './Container/Container';
 import './ExperienceFragment/ExperienceFragment';
+
+import {MapTo} from '@adobe/aem-react-editable-components';
+
+import {
+    ContainerV1, ContainerV1IsEmptyFn,
+    TabsV1, TabsV1IsEmptyFn,
+    AccordionV1,AccordionV1IsEmptyFn,
+    CarouselV1,CarouselV1IsEmptyFn
+} from '@adobe/aem-core-components-react-spa';
+
+import {
+    TitleV2,TitleV2IsEmptyFn,
+    BreadCrumbV2,BreadCrumbV2IsEmptyFn,
+    ButtonV1,ButtonV1IsEmptyFn,
+    ImageV2,ImageV2IsEmptyFn,
+    LanguageNavigationV1,
+    NavigationV1,
+    TeaserV1,TeaserV1IsEmptyFn,
+    DownloadV1,DownloadV1IsEmptyFn,
+    SeparatorV1,SeparatorV1IsEmptyFn,
+    ListV2,ListV2IsEmptyFn
+} from '@adobe/aem-core-components-react-base';
+
+MapTo('${projectName}/components/download')(DownloadV1, {isEmpty: DownloadV1IsEmptyFn});
+MapTo('${projectName}/components/list')(ListV2, {isEmpty: ListV2IsEmptyFn});
+MapTo('${projectName}/components/separator')(SeparatorV1, {isEmpty: SeparatorV1IsEmptyFn});
+MapTo('${projectName}/components/breadcrumb')(BreadCrumbV2, {isEmpty: BreadCrumbV2IsEmptyFn});
+MapTo('${projectName}/components/button')(ButtonV1, {isEmpty: ButtonV1IsEmptyFn});
+MapTo('${projectName}/components/teaser')(TeaserV1, {isEmpty: TeaserV1IsEmptyFn});
+MapTo('${projectName}/components/image')(ImageV2, {isEmpty: ImageV2IsEmptyFn});
+MapTo('${projectName}/components/title')(TitleV2, {isEmpty: TitleV2IsEmptyFn});
+
+MapTo('${projectName}/components/navigation')(NavigationV1);
+MapTo('${projectName}/components/languagenavigation')(LanguageNavigationV1);
+
+MapTo('${projectName}/components/tabs')(TabsV1, {isEmpty: TabsV1IsEmptyFn});
+MapTo('${projectName}/components/accordion')(AccordionV1, {isEmpty: AccordionV1IsEmptyFn});
+MapTo('${projectName}/components/carousel')(CarouselV1, {isEmpty: CarouselV1IsEmptyFn});
+MapTo('${projectName}/components/container')(ContainerV1, {isEmpty: ContainerV1IsEmptyFn});

--- a/src/main/archetype/ui.frontend.react/src/components/import-components.js
+++ b/src/main/archetype/ui.frontend.react/src/components/import-components.js
@@ -41,19 +41,19 @@ import {
     ListV2,ListV2IsEmptyFn
 } from '@adobe/aem-core-components-react-base';
 
-MapTo('${projectName}/components/download')(DownloadV1, {isEmpty: DownloadV1IsEmptyFn});
-MapTo('${projectName}/components/list')(ListV2, {isEmpty: ListV2IsEmptyFn});
-MapTo('${projectName}/components/separator')(SeparatorV1, {isEmpty: SeparatorV1IsEmptyFn});
-MapTo('${projectName}/components/breadcrumb')(BreadCrumbV2, {isEmpty: BreadCrumbV2IsEmptyFn});
-MapTo('${projectName}/components/button')(ButtonV1, {isEmpty: ButtonV1IsEmptyFn});
-MapTo('${projectName}/components/teaser')(TeaserV1, {isEmpty: TeaserV1IsEmptyFn});
-MapTo('${projectName}/components/image')(ImageV2, {isEmpty: ImageV2IsEmptyFn});
-MapTo('${projectName}/components/title')(TitleV2, {isEmpty: TitleV2IsEmptyFn});
+MapTo('${appId}/components/download')(DownloadV1, {isEmpty: DownloadV1IsEmptyFn});
+MapTo('${appId}/components/list')(ListV2, {isEmpty: ListV2IsEmptyFn});
+MapTo('${appId}/components/separator')(SeparatorV1, {isEmpty: SeparatorV1IsEmptyFn});
+MapTo('${appId}/components/breadcrumb')(BreadCrumbV2, {isEmpty: BreadCrumbV2IsEmptyFn});
+MapTo('${appId}/components/button')(ButtonV1, {isEmpty: ButtonV1IsEmptyFn});
+MapTo('${appId}/components/teaser')(TeaserV1, {isEmpty: TeaserV1IsEmptyFn});
+MapTo('${appId}/components/image')(ImageV2, {isEmpty: ImageV2IsEmptyFn});
+MapTo('${appId}/components/title')(TitleV2, {isEmpty: TitleV2IsEmptyFn});
 
-MapTo('${projectName}/components/navigation')(NavigationV1);
-MapTo('${projectName}/components/languagenavigation')(LanguageNavigationV1);
+MapTo('${appId}/components/navigation')(NavigationV1);
+MapTo('${appId}/components/languagenavigation')(LanguageNavigationV1);
 
-MapTo('${projectName}/components/tabs')(TabsV1, {isEmpty: TabsV1IsEmptyFn});
-MapTo('${projectName}/components/accordion')(AccordionV1, {isEmpty: AccordionV1IsEmptyFn});
-MapTo('${projectName}/components/carousel')(CarouselV1, {isEmpty: CarouselV1IsEmptyFn});
-MapTo('${projectName}/components/container')(ContainerV1, {isEmpty: ContainerV1IsEmptyFn});
+MapTo('${appId}/components/tabs')(TabsV1, {isEmpty: TabsV1IsEmptyFn});
+MapTo('${appId}/components/accordion')(AccordionV1, {isEmpty: AccordionV1IsEmptyFn});
+MapTo('${appId}/components/carousel')(CarouselV1, {isEmpty: CarouselV1IsEmptyFn});
+MapTo('${appId}/components/container')(ContainerV1, {isEmpty: ContainerV1IsEmptyFn});


### PR DESCRIPTION
## Description

Adds the basic core components to the React / Angular SPA, such as Carousel, Tabs, Download etc.

## Related Issue

https://github.com/adobe/aem-project-archetype/issues/584

## Motivation and Context

This will make partners aware that we have react / angular core components, and therefore don't need to reinvent the wheel.

## How Has This Been Tested?

Unit Tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.