### PR TITLE
CIF-1911: Add category references tab + picker for XF to AEM project archetype

### DIFF
--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/components/xfpage/_cq_dialog/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/components/xfpage/_cq_dialog/.content.xml
@@ -95,6 +95,29 @@
                                                 targetProperty="jcr:content/cq:products"/>
                                         </items>
                                     </productsPickerSection>
+                                    <categoriesPickerSection
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Category selection"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/fieldset">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <categories
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="commerce/gui/components/common/cifcategoryfield"
+                                                fieldDescription="Select the categories associated with this experience fragment variation."
+                                                fieldLabel="Category IDs."
+                                                multiple="{Boolean}true"
+                                                name="./cq:categories"
+                                                selectionId="id">
+                                                <granite:data
+                                                    jcr:primaryType="nt:unstructured"
+                                                    metaType="text"/>
+                                            </categories>
+                                            <categoriestab
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="commerce/gui/components/common/categoryreferencetab"
+                                                targetProperty="jcr:content/cq:categories"/>
+                                        </items>
+                                    </categoriesPickerSection>
 #end
                                 </items>
                             </column>


### PR DESCRIPTION
 Add category references tab and picker to XF component (cloud only)

## How Has This Been Tested?

Manual testing

See https://github.com/adobe/aem-cif-guides-venia/pull/97 for results in Venia project

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.