### PR TITLE
[Site30] Allow theme artifacts

### DIFF
--- a/src/main/archetype/dispatcher.cloud/src/conf.dispatcher.d/filters/filters.any
+++ b/src/main/archetype/dispatcher.cloud/src/conf.dispatcher.d/filters/filters.any
@@ -11,3 +11,6 @@ $include "./default_filters.any"
 
 # Allow manifest.webmanifest files located in the content
 /0102 { /type "allow" /extension "webmanifest" /path "/content/*/manifest" }
+
+# Allow theme artifacts
+/0103 { /type "allow" /extension "theme" /path "/content/*" }


### PR DESCRIPTION
Site30 is requesting theme artifacts with the `theme` extension (for example `/content/test.theme/_default/css/theme.css`)
