### PR TITLE
update htl-maven-plugin

### DIFF
--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -295,7 +295,7 @@ Bundle-DocURL:
                 <plugin>
                     <groupId>org.apache.sling</groupId>
                     <artifactId>htl-maven-plugin</artifactId>
-                    <version>1.3.4-1.4.0</version>
+                    <version>2.0.2-1.4.0</version>
                     <configuration>
                         <failOnWarnings>true</failOnWarnings>
                     </configuration>

--- a/src/main/archetype/ui.apps/pom.xml
+++ b/src/main/archetype/ui.apps/pom.xml
@@ -39,7 +39,7 @@
     <!-- B U I L D   D E F I N I T I O N                                        -->
     <!-- ====================================================================== -->
     <build>
-        <sourceDirectory>src/main/content/jcr_root</sourceDirectory>
+        <scriptSourceDirectory>src/main/content/jcr_root</scriptSourceDirectory>
         <plugins>
             <!-- ====================================================================== -->
             <!-- V A U L T   P A C K A G E   P L U G I N S                              -->
@@ -269,14 +269,8 @@
         <!-- HTL dependencies needed for the HTL Maven Plugin source code generation -->
         <dependency>
             <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.scripting.sightly.compiler</artifactId>
-            <version>1.2.4-1.4.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.scripting.sightly.runtime</artifactId>
-            <version>1.2.0-1.4.0</version>
+            <version>1.2.4-1.4.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
- update to new version of the htl-maven-plugin and org.apache.sling.scripting.sightly.runtime dependency
- remove obsolete org.apache.sling.scripting.sightly.compiler dependency fixes #614
- replaced sourceDirectory with scriptSourceDirectory