### PR TITLE
Update aemanalyser-maven-plugin to version 0.9.0

### DIFF
--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -98,7 +98,7 @@
 #end
 #if ( $aemVersion == "cloud")
         <aem.sdk.api>SDK_VERSION</aem.sdk.api>
-        <aemanalyser.version>0.0.18</aemanalyser.version>
+        <aemanalyser.version>0.9.0</aemanalyser.version>
 #end
         <componentGroupName>$appTitle</componentGroupName>
     </properties>


### PR DESCRIPTION
This update includes support for CIF add-ons in the aemanalyser-maven-plugin.