### PR TITLE
remove classifier for uber-jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Name                      | Default        | Description
 
 Archetype | AEM as a Cloud Service | AEM 6.5 | AEM 6.4 | Java SE | Maven
 ---------|---------|---------|---------|---------|---------
-[25](https://github.com/adobe/aem-project-archetype/releases/tag/aem-project-archetype-25) | Continual | 6.5.5.0+ | 6.4.8.1+ | 8, 11 | 3.3.9+
+[25](https://github.com/adobe/aem-project-archetype/releases/tag/aem-project-archetype-25) | Continual | 6.5.7.0+ | 6.4.8.4+ | 8, 11 | 3.3.9+
 
 Setup your local development environment for [AEM as a Cloud Service SDK](https://docs.adobe.com/content/help/en/experience-manager-learn/cloud-service/local-development-environment-set-up/overview.html) or for [older versions of AEM](https://docs.adobe.com/content/help/en/experience-manager-learn/foundation/development/set-up-a-local-aem-development-environment.html).
 

--- a/src/main/archetype/core/pom.xml
+++ b/src/main/archetype/core/pom.xml
@@ -156,7 +156,6 @@ Import-Package: javax.annotation;version=0.0.0,*
         <dependency>
             <groupId>com.adobe.aem</groupId>
             <artifactId>uber-jar</artifactId>
-            <classifier>apis</classifier>
         </dependency>
         <dependency>
             <groupId>com.adobe.cq</groupId>

--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -712,7 +712,6 @@ Bundle-DocURL:
                 <groupId>com.adobe.aem</groupId>
                 <artifactId>uber-jar</artifactId>
                 <version>$aemVersion</version>
-                <classifier>apis</classifier>
                 <scope>provided</scope>
             </dependency>
             <!-- Apache Sling Dependencies -->

--- a/src/main/archetype/ui.apps/pom.xml
+++ b/src/main/archetype/ui.apps/pom.xml
@@ -196,7 +196,6 @@
         <dependency>
             <groupId>com.adobe.aem</groupId>
             <artifactId>uber-jar</artifactId>
-            <classifier>apis</classifier>
         </dependency>
 
         <dependency>

--- a/src/main/archetype/ui.content/pom.xml
+++ b/src/main/archetype/ui.content/pom.xml
@@ -98,7 +98,6 @@
         <dependency>
             <groupId>com.adobe.aem</groupId>
             <artifactId>uber-jar</artifactId>
-            <classifier>apis</classifier>
         </dependency>
 #else
         <dependency>


### PR DESCRIPTION
- remove classifier from uber-jar dependency
- update minimum 6.4 and 6.5 AEM version in system requirements

fixes #607 