### PR TITLE
Replace `webpack-import-glob-loader` with `glob-import-loader`.

### DIFF
--- a/src/main/archetype/ui.frontend.general/package.json
+++ b/src/main/archetype/ui.frontend.general/package.json
@@ -33,6 +33,7 @@
     "cssnano": "^4.1.10",
     "eslint": "^6.8.0",
     "eslint-loader": "^3.0.3",
+    "glob-import-loader": "^1.1.4",
     "html-webpack-plugin": "^3.2.0",
     "mini-css-extract-plugin": "^0.4.4",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
@@ -49,7 +50,6 @@
     "webpack": "^4.27.1",
     "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^3.9.0",
-    "webpack-import-glob-loader": "^1.6.3",
     "webpack-merge": "^4.2.1"
   },
   "dependencies": {},

--- a/src/main/archetype/ui.frontend.general/webpack.common.js
+++ b/src/main/archetype/ui.frontend.general/webpack.common.js
@@ -9,13 +9,15 @@ const { CleanWebpackPlugin }  = require('clean-webpack-plugin');
 
 const SOURCE_ROOT = __dirname + '/src/main/webpack';
 
+const resolve = {
+    extensions: ['.js', '.ts'],
+    plugins: [new TSConfigPathsPlugin({
+        configFile: './tsconfig.json'
+    })]
+};
+
 module.exports = {
-    resolve: {
-        extensions: ['.js', '.ts'],
-        plugins: [new TSConfigPathsPlugin({
-            configFile: './tsconfig.json'
-        })]
-    },
+    resolve: resolve,
     entry: {
         site: SOURCE_ROOT + '/site/main.ts'
     },
@@ -41,9 +43,9 @@ module.exports = {
                         loader: 'ts-loader'
                     },
                     {
-                        loader: 'webpack-import-glob-loader',
+                        loader: 'glob-import-loader',
                         options: {
-                            url: false
+                            resolve: resolve
                         }
                     }
                 ]
@@ -80,9 +82,9 @@ module.exports = {
                         }
                     },
                     {
-                        loader: 'webpack-import-glob-loader',
+                        loader: 'glob-import-loader',
                         options: {
-                            url: false
+                            resolve: resolve
                         }
                     }
                 ]


### PR DESCRIPTION
## Description

I've replaced the `webpack-import-glob-loader` dev dependency with `glob-import-loader`.

## Related Issue

#630 

## Motivation and Context

The dependency [`webpack-import-glob-loader`](https://github.com/adobe/aem-project-archetype/blob/master/src/main/archetype/ui.frontend.general/package.json#L52) has been left untouched for 2 years after being forked [from a project](https://github.com/terpiljenya/import-glob) which was been untouched for 4 years. It still works fine for most cases but I've run across a couple of issues:

1. It does not support the new Sass at-rules [@use](https://sass-lang.com/documentation/at-rules/use) and [@forward](https://sass-lang.com/documentation/at-rules/forward). Granted, the plugin is called webpack-_import_-glob-loader, however, the [@import directive has been deprecated](https://sass-lang.com/documentation/at-rules/import) by the Sass team.
2. Webpack's resolver configuration (like aliasing) doesn't work with the plugin.

## How Has This Been Tested?

I've been using `glob-import-loader` on multiple AEM projects professionally. Additionally, I swapped the dependency and ran it locally to verify.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
