### PR TITLE
Add support for webpack dev server to inject in-memory build assets into AEM served pages

### DIFF
--- a/src/main/archetype/ui.frontend.general/package.json
+++ b/src/main/archetype/ui.frontend.general/package.json
@@ -50,7 +50,8 @@
     "webpack": "^4.27.1",
     "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^3.9.0",
-    "webpack-merge": "^4.2.1"
+    "webpack-merge": "^4.2.1",
+    "webpack-dev-server-inject-scripts": "^0.1.3"
   },
   "dependencies": {},
   "browserslist": [

--- a/src/main/archetype/ui.frontend.general/webpack.dev.js
+++ b/src/main/archetype/ui.frontend.general/webpack.dev.js
@@ -2,16 +2,17 @@ const merge             = require('webpack-merge');
 const common            = require('./webpack.common.js');
 const path              = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const injectScripts     = require('webpack-dev-server-inject-scripts');
 
 const SOURCE_ROOT = __dirname + '/src/main/webpack';
 
 module.exports = env => {
-    const writeToDisk = env && Boolean(env.writeToDisk);
 
     return merge(common, {
         mode: 'development',
         devtool: 'inline-source-map',
         performance: { hints: 'warning' },
+        publicPath: '/',
         plugins: [
             new HtmlWebpackPlugin({
                 template: path.resolve(__dirname, SOURCE_ROOT + '/static/index.html')
@@ -20,11 +21,15 @@ module.exports = env => {
         devServer: {
             inline: true,
             proxy: [{
-                context: ['/content', '/etc.clientlibs'],
+                context: [
+                    '/content',
+                    '/etc.clientlibs/opp/clientlibs/clientlib-base.*.*'
+                ],
                 target: 'http://localhost:4502',
             }],
-            writeToDisk,
-            liveReload: !writeToDisk
+            before: (app, server, compiler) => {
+                app.use(injectScripts(compiler));
+            };
         }
     });
 }

--- a/src/main/archetype/ui.frontend.react/cracoConfig.js
+++ b/src/main/archetype/ui.frontend.react/cracoConfig.js
@@ -1,0 +1,13 @@
+const injectScripts = require('webpack-dev-server-inject-scripts');
+
+
+module.exports = {
+    devServer: (devServerConfig) => {
+        const before = devServerConfig.before;
+        devServerConfig.before = (app, server, compiler) => {
+            app.use(injectScripts(compiler));
+            before(app, server, compiler);
+        };
+        return devServerConfig;
+    },
+};

--- a/src/main/archetype/ui.frontend.react/package.json
+++ b/src/main/archetype/ui.frontend.react/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "start": "react-scripts start",
+    "start": "craco start",
     "build": "react-scripts build && clientlib",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
@@ -32,7 +32,9 @@
     "aemsync": "^4.0.0",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.15.1",
-    "sinon": "^7.5.0"
+    "sinon": "^7.5.0",
+    "@craco/craco": "5.8.0",
+    "http-proxy-middleware": "1.0.6"
   },
   "proxy": "http://localhost:4502",
   "browserslist": [

--- a/src/main/archetype/ui.frontend.react/src/setupProxy.js
+++ b/src/main/archetype/ui.frontend.react/src/setupProxy.js
@@ -1,0 +1,14 @@
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+module.exports = function(app) {
+    app.use(
+        [
+            '/content',
+            '/etc.clientlibs/opp/clientlibs/clientlib-base.*.*',
+        ],
+        createProxyMiddleware({
+            target: 'http://localhost:4502',
+            changeOrigin: true,
+        })
+    );
+};


### PR DESCRIPTION
## Description

Webpack dev server should proxy content pages from AEM and inject it's in-memory assets in the page. This way the dev server will create the bundles in memory. Webpack provisioned clientlibs should not be proxied.

For the ui.frontend.react, this requires rewiring the CRA Webpack config.

## Related Issue

#631

## Motivation and Context

Webpack dev server only proxies, but still requires a build to provision the clientlibs. Live reloading is not supported with watch.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.