### PR TITLE
Adding .gitattributes file to archetype assets

### DIFF
--- a/.github/workflows/maven-deploy-cm.yml
+++ b/.github/workflows/maven-deploy-cm.yml
@@ -1,0 +1,80 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Copyright 2020 Adobe Systems Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+name: Deploy to Cloud Manager
+env:
+  ARCHETYPE_DIR: archetype
+  CM_PROJECT_DIR: cm-project
+  # Cloud Manager connection details
+  CM_REPO: ${{ secrets.CM_REPO }}
+  CM_BRANCH: ${{ secrets.CM_BRANCH }}
+  CM_USER_EMAIL: ${{ secrets.CM_USER_EMAIL }}
+  CM_USER_NAME: ${{ secrets.CM_USER_NAME }}
+  CM_USER_PWD: ${{ secrets.CM_USER_PWD }}
+
+# Only run on a push to develop branch or manually
+on:
+  push:
+    branches: [ develop ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout this project into a sub folder
+      - uses: actions/checkout@v2
+        with:
+          path: ${ARCHETPE_DIR}
+      # Install archetype snapshot and store version in a variable
+      - name: Clean project
+        run: |
+          cd ${ARCHETYPE_DIR}
+          mvn clean install -DskipTests
+          echo "ARCHETYPE_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)" >> $GITHUB_ENV
+          cd ..
+      # Create new project
+      - name: Create new project with the archetype
+        run: |
+          mvn -B archetype:generate \
+           -D archetypeGroupId=com.adobe.aem \
+           -D archetypeArtifactId=aem-project-archetype \
+           -D archetypeVersion=${ARCHETYPE_VERSION} \
+           -D appTitle="Sites 30 Demo" \
+           -D appId="sitesdemo" \
+           -D groupId="com.sites30demo"
+      # Set global git configuration
+      - name: Set git config
+        run: |
+          git config --global credential.helper cache
+          git config --global user.email ${CM_USER_EMAIL}
+          git config --global user.name ${CM_USER_NAME}
+      # Checkout the CM project
+      - name: Checkout Cloud Manager project
+        run:
+          git clone -b ${CM_BRANCH} https://${CM_USER_NAMEL}:${CM_USER_PWD}@${CM_REPO} ${CM_PROJECT_DIR}
+      # Move new project to CM dir
+      - name: Move project to CM dir
+        run: |
+          git -C ${CM_PROJECT_DIR} rm -rf .
+          mv sitesdemo/* ${CM_PROJECT_DIR}
+      # Commit and push changes to CM repo
+      - name: Commit Changes
+        run: |
+          git -C ${ARCHETYPE_DIR} log --format="%an : %s" -n 1 > commit.txt
+          git -C ${CM_PROJECT_DIR} add .
+          git -C ${CM_PROJECT_DIR} commit -F ../commit.txt
+          git -C ${CM_PROJECT_DIR} push

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To generate a project, adjust the following command line to your needs:
 mvn -B archetype:generate \
  -D archetypeGroupId=com.adobe.aem \
  -D archetypeArtifactId=aem-project-archetype \
- -D archetypeVersion=25 \
+ -D archetypeVersion=26 \
  -D appTitle="My Site" \
  -D appId="mysite" \
  -D groupId="com.mysite"
@@ -94,7 +94,7 @@ Name                      | Default        | Description
 
 Archetype | AEM as a Cloud Service | AEM 6.5 | AEM 6.4 | Java SE | Maven
 ---------|---------|---------|---------|---------|---------
-[25](https://github.com/adobe/aem-project-archetype/releases/tag/aem-project-archetype-25) | Continual | 6.5.5.0+ | 6.4.8.1+ | 8, 11 | 3.3.9+
+[26](https://github.com/adobe/aem-project-archetype/releases/tag/aem-project-archetype-26) | Continual | 6.5.5.0+ | 6.4.8.1+ | 8, 11 | 3.3.9+
 
 Setup your local development environment for [AEM as a Cloud Service SDK](https://docs.adobe.com/content/help/en/experience-manager-learn/cloud-service/local-development-environment-set-up/overview.html) or for [older versions of AEM](https://docs.adobe.com/content/help/en/experience-manager-learn/foundation/development/set-up-a-local-aem-development-environment.html).
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -20,3 +20,4 @@ Archetype Version | AEM Version
 20, 21, 22        | 6.5, 6.4, 6.3 + SP3
 23                | 6.5, 6.4, 6.3 + SP3, AEM as a Cloud Service
 24                | 6.5.5, 6.4.8.1, AEM as a Cloud Service
+25                | 6.5.5, 6.4.8.1, AEM as a Cloud Service

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>com.adobe.aem</groupId>
     <artifactId>aem-project-archetype</artifactId>
-    <version>26-SNAPSHOT</version>
+    <version>27-SNAPSHOT</version>
     <packaging>maven-archetype</packaging>
 
     <name>AEM Multi-Module Archetype</name>

--- a/src/main/archetype/.gitattributes
+++ b/src/main/archetype/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto
+
+*.conf text
+*.vhost text
+*.rules text
+*.vars text
+*.any text
+magic text

--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -98,7 +98,7 @@
 #end
 #if ( $aemVersion == "cloud")
         <aem.sdk.api>SDK_VERSION</aem.sdk.api>
-        <aemanalyser.version>0.9.0</aemanalyser.version>
+        <aemanalyser.version>0.9.2</aemanalyser.version>
 #end
         <componentGroupName>$appTitle</componentGroupName>
     </properties>


### PR DESCRIPTION
Adding .gitattributes file to archetype assets to avoid invalid line endings on immutable dispatcher files


## Description

Adding the .gitattributes file will unify line ending handling for committers using different operating systems so that the immutable Dispatcher files do not get corrupted during commits.

## Related Issue

Fixes #661 

## Motivation and Context

In certain development environments that may be configured with different GIT line ending configurations, it is possible for developers to unwillingly commit files with invalid line endings which will break the Dispatcher module's immutable file check due to invalid MD5 hashes.

## How Has This Been Tested?

Followed the steps to reproduce documented in #661 but the project build was now successful

## Screenshots (if appropriate):
N/A

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.