### PR TITLE
Remove setting that adds User-Agent to vary header

### DIFF
--- a/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/000_unhealthy_author.vhost
+++ b/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/000_unhealthy_author.vhost
@@ -12,8 +12,6 @@
 		# Don't compress images
 		SetEnvIfNoCase Request_URI \
 		\.(?:gif|jpe?g|png)$ no-gzip dont-vary
-		# Make sure proxies don't deliver the wrong content
-		Header append Vary User-Agent env=!dont-vary
 	</Directory>
 	<Directory "/mnt/var/www/default">
 		AllowOverride None

--- a/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/000_unhealthy_publish.vhost
+++ b/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/000_unhealthy_publish.vhost
@@ -12,8 +12,6 @@
 		# Don't compress images
 		SetEnvIfNoCase Request_URI \
 		\.(?:gif|jpe?g|png)$ no-gzip dont-vary
-		# Make sure proxies don't deliver the wrong content
-		Header append Vary User-Agent env=!dont-vary
 	</Directory>
 	<Directory "/mnt/var/www/default">
 		AllowOverride None

--- a/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/__appId___publish.vhost
+++ b/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/__appId___publish.vhost
@@ -14,8 +14,6 @@ PassEnv DISP_ID
 		Header always add X-Vhost "publish"
 		Header merge X-Frame-Options SAMEORIGIN "expr=%{resp:X-Frame-Options}!='SAMEORIGIN'"
 		Header merge X-Content-Type-Options nosniff "expr=%{resp:X-Content-Type-Options}!='nosniff'"
-		# Make sure proxies don't deliver the wrong content
-		Header append Vary User-Agent env=!dont-vary
 	</IfModule>
 	<Directory />
 		# Update /etc/sysconfig/httpd with setting the PUBLISH_ALLOWLIST_ENABLED from 0 or 1 to enable or disable ip restriction rules

--- a/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/aem_author.vhost
+++ b/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/aem_author.vhost
@@ -15,8 +15,6 @@ PassEnv DISP_ID
 		Header always add X-Vhost "author"
 		Header merge X-Frame-Options SAMEORIGIN "expr=%{resp:X-Frame-Options}!='SAMEORIGIN'"
 		Header merge X-Content-Type-Options nosniff "expr=%{resp:X-Content-Type-Options}!='nosniff'"
-		# Make sure proxies don't deliver the wrong content
-		Header append Vary User-Agent env=!dont-vary
 		# Force SSL for author
 		# Add HSTS for avoiding man in the middle during browser redirect to SSL
 		Header always set Strict-Transport-Security "max-age=63072000; includeSubdomains;"

--- a/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/aem_lc.vhost
+++ b/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/aem_lc.vhost
@@ -12,8 +12,6 @@
 		Header merge X-Frame-Options SAMEORIGIN "expr=%{resp:X-Frame-Options}!='SAMEORIGIN'"
 		Header always set Strict-Transport-Security "max-age=63072000; includeSubdomains;"
 		Header merge X-Content-Type-Options nosniff "expr=%{resp:X-Content-Type-Options}!='nosniff'"
-		# Make sure proxies don't deliver the wrong content
-		Header append Vary User-Agent env=!dont-vary
 	</IfModule>
 	<Directory />
 		# Update /etc/sysconfig/httpd with setting the LIVECYCLE_ALLOWLIST_ENABLED from 0 or 1 to enable or disable ip restriction rules

--- a/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/aem_publish.vhost
+++ b/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/aem_publish.vhost
@@ -16,8 +16,6 @@ PassEnv DISP_ID
 		Header always add X-Vhost "publish"
 		Header merge X-Frame-Options SAMEORIGIN "expr=%{resp:X-Frame-Options}!='SAMEORIGIN'"
 		Header merge X-Content-Type-Options nosniff "expr=%{resp:X-Content-Type-Options}!='nosniff'"
-		# Make sure proxies don't deliver the wrong content
-		Header append Vary User-Agent env=!dont-vary
 		# Force SSL for author
 		# Add HSTS for avoiding man in the middle during browser redirect to SSL
 		Header always set Strict-Transport-Security "max-age=63072000; includeSubdomains;"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Remove User-Agent from vary header to improve caching on CDN/proxy

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.