### PR TITLE
Added script for fetching static content

### DIFF
--- a/src/main/archetype/ui.frontend.general/README.md
+++ b/src/main/archetype/ui.frontend.general/README.md
@@ -28,6 +28,7 @@ The following npm scripts drive the frontend workflow:
 * `npm run dev` - Full build of client libraries with JS optimization disabled (tree shaking, etc) and source maps enabled and CSS optimization disabled.
 * `npm run prod` - Full build of client libraries build with JS optimization enabled (tree shaking, etc), source maps disabled and CSS optimization enabled.
 * `npm run start` - Starts a static webpack development server for local development with minimal dependencies on AEM.
+* `npm run scrape` - Downloads the specified pages' HTML and saves it as static files for use by the webpack development server. See `Scraper Configurtion` section
 
 ${hash}${hash}${hash} General
 
@@ -107,4 +108,46 @@ ${hash}${hash}${hash}${hash} Using
 1. From within the root of the project run the command `mvn -PautoInstallSinglePackage clean install` to install the entire project to an AEM instance running at `localhost:4502`
 2. Navigate inside the `ui.frontend` folder.
 3. Run the following command `npm run start` to start the webpack dev server. Once started it should open a browser (localhost:8080 or the next available port).
-4. You can now modify CSS, JS, SCSS, and TS files and see the changes immediately reflected in the webpack dev server.
+4. You can now modify CSS, JS, SCSS, and TS files and see the changes immediately reflected in the webpack dev server. 
+
+${hash}${hash}${hash} Scraper configuration
+
+The scraper downloads the specified AEM pages as static HTML files and saves to the `src/main/webpack/site/static/` directory. It's used by the webpack development server.
+It can be run with the `npm run scrape` command.
+It can be configured either by passing command line arguments or using a configuration file (by default `scraper.config.json`).
+Note that not all options can be set by command line parameters. Configuration file must contain `index` property which define a page that will be downloaded and saved into `webpack/static/index.html`
+
+${hash}${hash}${hash}${hash} Command line parameters
+Example of specifying a custom instance and password:
+```bash
+npm run scrape -- --host http://localhost:1234 --pass mypassword42
+```
+
+All the options:
+
+Option | Alias | Default value | Description
+--- | --- | --- | ---
+--help | -h | n/a | Shows this table
+--dir | -d | n/a | Directory to save the files to
+--page | -p | n/a | AEM page to download as index.html
+--config | -c | ./scraper.config.json | Configuration file
+--host | n/a | http://localhost:4502 | AEM instance url
+--user | n/a | admin | AEM username
+--pass | n/a | admin | AEM password
+
+${hash}${hash}${hash}${hash} Configuration file
+
+By default, the `scraper.config.json` file is used. Sample configuration:
+
+```json
+{
+    "dir": "./src/main/webpack/static",
+    "index": "content/${appId}/us/en.html",
+    "pages": [
+        "content/${appId}/us/en.html",
+        "content/${appId}/us.html"
+    ]
+}
+```
+
+The same options can be set as via the CLI. Additional pages to download can also be specified via the `pages` array. The necessary directory structure will be created.

--- a/src/main/archetype/ui.frontend.general/devtools/aemscraper.js
+++ b/src/main/archetype/ui.frontend.general/devtools/aemscraper.js
@@ -1,0 +1,45 @@
+const fetch = require('node-fetch');
+const fs = require('fs');
+const path = require('path')
+const { Command } = require('commander');
+
+const program = new Command();
+
+program
+    .option('-d, --dir <path>', 'Directory to save the files to')
+    .option('-p, --page <index>', 'AEM page to download as index.html')
+    .option('-c, --config <config>', 'Config file', './scraper.config.json')
+    .option('--host <host>', 'AEM instance url', 'http://localhost:4502')
+    .option('--user <user>', 'AEM username', 'admin')
+    .option('--pass <pass>', 'AEM password', 'admin');
+
+program.parse(process.argv);
+const options = program.opts();
+
+const config = JSON.parse(fs.readFileSync(options.config, 'utf8'));
+
+config.dir = options.dir || config.dir;
+config.index = options.index || config.index;
+config.host = options.host || config.host;
+config.user = options.user || config.user;
+config.pass = options.pass || config.pass;
+config.pages = config.pages || [];
+
+const headers = {
+    'Authorization': 'Basic ' + Buffer.from(`${config.user}:${config.pass}`).toString('base64')
+};
+
+const indexData = { file: 'index.html', page: config.index };
+const pagesData = config.pages.map(page => ({ file: page, page }));
+
+new Array(indexData).concat(pagesData).forEach(data => {
+    const url = `${config.host}/${data.page}`;
+    const file = `${config.dir}/${data.file}`;
+
+    fetch(url, { method: 'GET', headers })
+        .then(res => res.text())
+        .then(body => fs.promises.mkdir(path.dirname(file), { recursive:true })
+            .then(() => fs.promises.writeFile(file, body, 'utf-8')))
+        .then(() => console.log(`AEM Page saved to disk:\n- page: ${url}\n- file: ${file}`))
+        .catch(error => console.error(error));
+});

--- a/src/main/archetype/ui.frontend.general/package.json
+++ b/src/main/archetype/ui.frontend.general/package.json
@@ -13,6 +13,7 @@
     "dev": "webpack -d --env dev --config ./webpack.dev.js && clientlib --verbose",
     "prod": "webpack -p --config ./webpack.prod.js && clientlib --verbose",
     "start": "webpack-dev-server --open --config ./webpack.dev.js",
+    "scrape": "node devtools/aemscraper.js",
     "sync": "aemsync -d -p ../ui.apps/src/main/content",
     "watch": "webpack-dev-server --config ./webpack.dev.js --env.writeToDisk & watch 'clientlib' ./dist & aemsync -w ../ui.apps/src/main/content"
   },

--- a/src/main/archetype/ui.frontend.general/scraper.config.json
+++ b/src/main/archetype/ui.frontend.general/scraper.config.json
@@ -1,0 +1,8 @@
+{
+    "dir": "./src/main/webpack/static",
+    "index": "content/${appId}/us/en.html",
+    "pages": [
+        "content/${appId}/us/en.html",
+        "content/${appId}/us.html"
+    ]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR includes additional script that automates updating static HTML content used in FE module with webpack dev server.

<!--- Describe your changes in detail -->

## Related Issue
#696 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Goal here is to simplify FE flow as much as possible to focus only on actual project related activities.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Running `npm run scrape` should update files under `static` directory according to configuration used. 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.