### PR TITLE
Include opt-in marker file for direct source mode for cloud dispatcher config

### DIFF
--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -250,6 +250,7 @@
                     <includes>
                         <include>**/README*</include>
                         <include>immutable.files</include>
+                        <include>**/opt-in/**</include>
                     </includes>
                 </fileSet>
             </fileSets>


### PR DESCRIPTION
## Description

Include opt-in marker file for direct source mode for cloud dispatcher config

## Related Issue

#703

## Motivation and Context

Cloud dispatcher config introduces direct source mode to apply dispatcher configs from _conf.d_ and _conf.dispatcher.d_ directly instead of the  limited one generated by dispatcher validator. To use this mode an opt-in file needs to exist in dispatcher config folder. Since this mode allows for more flexibility in cloud dispatcher config it should be enabled by default.

## How Has This Been Tested?

Generating new project from changed archetype:
```
mvn -B archetype:generate \
 -D archetypeGroupId=com.adobe.aem \
 -D archetypeArtifactId=aem-project-archetype \
 -D archetypeVersion=28-SNAPSHOT \
 -D appTitle="Use dispatcher sources directly mode" \
 -D appId="dispatcher-config-direct-sources" \
 -D groupId="com.adobe.aem" \
 -D aemVersion=cloud
```

Run `bin/validate.sh archetype/dispatcher-direct-config/dispatcher/src`:

```
$ bin/validate.sh src.arch.opt-in
opt-in USE_SOURCES_DIRECTLY marker file detected
Phase 1: Dispatcher validator
Cloud manager validator 2.0.30
2021/05/14 17:32:01 No issues found
Phase 1 finished
Phase 2: httpd -t validation in docker image
values.csv not found in deployment folder: /Users/someusername/archetype/dispatcher-direct-config/dispatcher/src - using files in 'conf.d' and 'conf.dispatcher.d' subfolders directly
processing configuration subfolder: conf.d
processing configuration subfolder: conf.dispatcher.d
(...)
```
See that the dispatcher config subfolders are used directly.

## Screenshots (if appropriate):

n/a

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.