### PR TITLE
CIF-2065 - Set affinity cookie for all requests in WDIO tests

### DIFF
--- a/src/main/archetype/ui.tests/test-module/lib/commons.js
+++ b/src/main/archetype/ui.tests/test-module/lib/commons.js
@@ -31,32 +31,38 @@ function takeScreenshot(browser, prefix) {
 }
 
 function getAuthenticatedRequestOptions(browser) {
-    let loginTokenCookie = _getLoginTokenCookie(browser);
+    let loginCookies = _getLoginCookies(browser);
     let jar = request.jar();
     let currentUrl = new URL(browser.getUrl());
 
-    jar.setCookie(loginTokenCookie.toString(), currentUrl.origin);
+    loginCookies.forEach(cookie => jar.setCookie(cookie.toString(), currentUrl.origin));
 
     return {
         jar: jar
     };
 }
 
-function _getLoginTokenCookie(browser) {
+function _getLoginCookies(browser) {
     let cookies = browser.getCookies();
-    let cookie = cookies.find(element => element.name == 'login-token');
 
-    if (!cookie) {
+    // Get login and affinity cookies only
+    let loginCookies = cookies.filter(e => ['login-token', 'affinity'].includes(e.name));
+
+    // Throw if mandatory login cookie is not there
+    if (!loginCookies.find(element => element.name == 'login-token')) {
         throw new Error('could not get login-token cookie');
     }
 
-    return new tough.Cookie({
-        key: cookie.name,
-        value: cookie.value,
-        httpOnly: cookie.httpOnly,
-        secure: false,
-        path: cookie.path
-    });
+    return loginCookies.map(
+        c =>
+            new tough.Cookie({
+                key: c.name,
+                value: c.value,
+                httpOnly: c.httpOnly,
+                secure: false,
+                path: c.path
+            })
+    );
 }
 
 class OnboardingDialogHandler {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Set `affinity` cookie when doing requests using the `request` library. The cookie is otherwise normally added for operations within the browser.
* The cookie is required for testing against AEMaaCS environments (not SDK) with multiple instances. Setting the cookie allows the test to run all requests against the same instance. 

## Related Issue

https://github.com/adobe/aem-cif-guides-venia/pull/135

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.