### PR TITLE
sync immutable file default_filters.any with dispatcher SDK 2.0.57

### DIFF
--- a/src/main/archetype/dispatcher.cloud/src/conf.dispatcher.d/filters/default_filters.any
+++ b/src/main/archetype/dispatcher.cloud/src/conf.dispatcher.d/filters/default_filters.any
@@ -86,3 +86,6 @@
 
 # GraphQL Persisted Queries & preflight requests
 /0061 { /type "allow" /method '(GET|POST|OPTIONS)' /url "/graphql/execute.json*" }
+
+# Allow Forms Doc Generation requests
+/0062 { /type "allow" /method "POST" /url "/adobe/forms/doc/*" }


### PR DESCRIPTION
sync immutable file _default_filters.any_ with dispatcher SDK 2.0.57

## Description

Syncing immutable file _default_filters.any_ from dispatcher SDK 2.0.57.

## Related Issue

#715
(follow up from #668 / #669)

## Motivation and Context

Immutable files should not be different between SDK and archetype.

## How Has This Been Tested?

Generating new project from changed archetype:
```
mvn -B archetype:generate \
 -D archetypeGroupId=com.adobe.aem \
 -D archetypeArtifactId=aem-project-archetype \
 -D archetypeVersion=28-SNAPSHOT \
 -D appTitle="Dispatcher config immutability check 2" \
 -D appId="dispatcher-config-immutability2" \
 -D groupId="com.adobe.aem" \
 -D aemVersion=cloud
```

Run `bin/validate.sh archetype/dispatcher-config-immutability2/dispatcher/src` against generated project successfully (including immutable config files check this time).

## Screenshots (if appropriate):

n/a

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.