### PR TITLE
CIF-2135 - Rename component to "Commerce Experience Fragment"

### DIFF
--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/components/commerce/experiencefragment/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/components/commerce/experiencefragment/.content.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
-    jcr:description="Commerce Experience Fragment Placeholder Component"
+    jcr:description="Commerce Experience Fragment Component"
     jcr:primaryType="cq:Component"
-    jcr:title="Commerce Experience Fragment Placeholder"
+    jcr:title="Commerce Experience Fragment"
     sling:resourceSuperType="core/cif/components/commerce/experiencefragment/v1/experiencefragment"
     componentGroup="${appTitle} - Commerce"/>


### PR DESCRIPTION
Changed title of commerce experience fragment component to "Commerce Experience Fragment".

## Related Issue

CIF-2135


## How Has This Been Tested?

Manually.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.