### PR TITLE
sync dispatcher immutable files with dispatcher SDK 2.0.60

### DIFF
--- a/src/main/archetype/dispatcher.cloud/src/conf.dispatcher.d/clientheaders/default_clientheaders.any
+++ b/src/main/archetype/dispatcher.cloud/src/conf.dispatcher.d/clientheaders/default_clientheaders.any
@@ -40,3 +40,4 @@
 "Sling-uploadmode"
 "x-requested-with"
 "If-Modified-Since"
+"Authorization"

--- a/src/main/archetype/dispatcher.cloud/src/conf.dispatcher.d/filters/default_filters.any
+++ b/src/main/archetype/dispatcher.cloud/src/conf.dispatcher.d/filters/default_filters.any
@@ -52,7 +52,7 @@
 
 # AEM Forms specific filters
 # to allow AF specific endpoints for prefill, submit and sign
-/0032 { /type "allow" /path "/content/forms/af/*" /method "POST" /selectors '(submit|internalsubmit|agreement|signSubmit|prefilldata)' /extension '(jsp|json)' }
+/0032 { /type "allow" /path "/content/forms/af/*" /method "POST" /selectors '(submit|internalsubmit|agreement|signSubmit|prefilldata|save)' /extension '(jsp|json)' }
 
 # to allow AF specific endpoints for thank you page
 /0033 { /type "allow" /path "/content/forms/af/*"  /method "GET" /selectors '(guideThankYouPage|guideAsyncThankYouPage)'  /extension '(html)'}


### PR DESCRIPTION
sync dispatcher immutable files with dispatcher SDK 2.0.60

## Description

Syncing dispatcher immutable files from dispatcher SDK 2.0.60.

## Related Issue

#739

## Motivation and Context

Immutable files should not be different between SDK and archetype.

## How Has This Been Tested?

Generating new project from changed archetype:
```
mvn -B archetype:generate \
  -D archetypeGroupId=com.adobe.aem \
  -D archetypeArtifactId=aem-project-archetype \
  -D archetypeVersion=28-SNAPSHOT \
  -D appTitle="Dispatcher config immutability check SDK 2.0.60" \
  -D appId="dispatcher-config-immutability-sdk-2-0-60" \
  -D groupId="com.adobe.aem" \
  -D aemVersion=cloud
```

Run `bin/validate.sh archetype/dispatcher-config-immutability-sdk-2-0-60/dispatcher/src` against generated project successfully (including immutable config files check this time).

## Screenshots (if appropriate):

n/a

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
