### PR TITLE
 integrating experience fragments support for the spa editor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    
+
     <groupId>com.adobe.aem</groupId>
     <artifactId>aem-project-archetype</artifactId>
     <version>28-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    
     <groupId>com.adobe.aem</groupId>
     <artifactId>aem-project-archetype</artifactId>
     <version>28-SNAPSHOT</version>

--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -90,7 +90,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 #if ( $isSpaProject )
-        <spa.project.core.version>1.3.0</spa.project.core.version>
+        <spa.project.core.version>1.3.4</spa.project.core.version>
 #end
 #if ( $frontendModule == "angular" )
         <!--

--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -90,7 +90,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 #if ( $isSpaProject )
-        <spa.project.core.version>1.3.4</spa.project.core.version>
+        <spa.project.core.version>1.4.0-SNAPSHOT</spa.project.core.version>
 #end
 #if ( $frontendModule == "angular" )
         <!--

--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -90,7 +90,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 #if ( $isSpaProject )
-        <spa.project.core.version>1.3.5-SNAPSHOT</spa.project.core.version>
+        <spa.project.core.version>1.3.6</spa.project.core.version>
 #end
 #if ( $frontendModule == "angular" )
         <!--

--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -90,7 +90,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 #if ( $isSpaProject )
-        <spa.project.core.version>1.4.0-SNAPSHOT</spa.project.core.version>
+        <spa.project.core.version>1.3.5-SNAPSHOT</spa.project.core.version>
 #end
 #if ( $frontendModule == "angular" )
         <!--

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/components/xfpage/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/components/xfpage/.content.xml
@@ -4,6 +4,8 @@
     jcr:title="${appTitle} Experience Fragment"
 #if ( $includeCommerce == "y" )
     sling:resourceSuperType="core/cif/components/structure/xfpage/v1/xfpage"
+#elseif ( $isSpaProject )
+    sling:resourceSuperType="spa-project-core/components/xf-page"
 #else
     sling:resourceSuperType="cq/experience-fragments/components/xfpage"
 #end

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/components/xfpage/body.html
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/components/xfpage/body.html
@@ -1,0 +1,18 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2020 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+
+<div id="spa-root" data-sly-resource="${symbol_dollar}{resource @ resourceType='cq/remote/content/renderer/request/handler'}"></div>
+<sly data-sly-include="footerlibs.html"/>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/components/xfpage/customfooterlibs.html
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/components/xfpage/customfooterlibs.html
@@ -13,6 +13,21 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */-->
+#if ( $isSpaProject )
+
+<sly data-sly-use.clientLib="${symbol_dollar}{'/libs/granite/sightly/templates/clientlib.html'}"></sly>
+<sly data-sly-test="${symbol_dollar}{wcmmode.edit || wcmmode.preview}"
+     data-sly-call="${symbol_dollar}{clientLib.js @ categories=['cq.authoring.pagemodel.messaging']}"></sly>
+
+<sly data-sly-call="${symbol_dollar}{clientlib.js @ categories=['testing-frontend-react.base']}"/>
+
+#else
+
 <sly data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html">
     <sly data-sly-call="${symbol_dollar}{clientlib.js @ categories='${appId}.base'}"/>
 </sly>
+
+#end
+
+
+

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/components/xfpage/customheaderlibs.html
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/components/xfpage/customheaderlibs.html
@@ -17,7 +17,7 @@
 
 <meta
         property="cq:pagemodel_root_url"
-        data-sly-use.page="com.adobe.aem.spa.project.core.models.Page"
+        data-sly-use.page="com.adobe.aem.spa.project.core.models.PageHierarchyRootExporter"
         content="${symbol_dollar}{page.hierarchyRootJsonExportUrl}"
 />
 

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/components/xfpage/customheaderlibs.html
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/components/xfpage/customheaderlibs.html
@@ -17,7 +17,7 @@
 
 <meta
         property="cq:pagemodel_root_url"
-        data-sly-use.page="com.adobe.aem.spa.project.core.models.PageHierarchyRootExporter"
+        data-sly-use.page="com.adobe.aem.spa.project.core.models.Page"
         content="${symbol_dollar}{page.hierarchyRootJsonExportUrl}"
 />
 

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/components/xfpage/customheaderlibs.html
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/components/xfpage/customheaderlibs.html
@@ -13,6 +13,29 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */-->
+#if ( $isSpaProject )
+
+<meta
+        property="cq:pagemodel_root_url"
+        data-sly-use.page="com.adobe.aem.spa.project.core.models.Page"
+        content="${symbol_dollar}{page.hierarchyRootJsonExportUrl}"
+/>
+
+<base href="/"/>
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+<meta property="cq:datatype" data-sly-test="${symbol_dollar}{wcmmode.edit || wcmmode.preview}" content="JSON"/>
+<meta property="cq:wcmmode" data-sly-test="${symbol_dollar}{wcmmode.edit}" content="edit"/>
+<meta property="cq:wcmmode" data-sly-test="${symbol_dollar}{wcmmode.preview}" content="preview"/>
+<meta property="cq:wcmmode" data-sly-test="${symbol_dollar}{wcmmode.disabled}" content="disabled"/>
+
+<sly data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html"/>
+
+<sly data-sly-call="${symbol_dollar}{clientlib.all @ categories=['coralui3']}"/>
+<sly data-sly-call="${symbol_dollar}{clientlib.css @ categories=['${appId}.base']}"/>
+
+#else
+
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <sly data-sly-use.clientLib="/libs/granite/sightly/templates/clientlib.html"
      data-sly-call="${symbol_dollar}{clientlib.js @ categories='${appId}.dependencies'}"/>
@@ -21,3 +44,5 @@
 
 <!--/* Include Context Hub */-->
 <sly data-sly-resource="${'contexthub' @ resourceType='granite/contexthub/components/contexthub'}"/>
+
+#end

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__appId__/settings/wcm/templates/spa-page-template/structure/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__appId__/settings/wcm/templates/spa-page-template/structure/.content.xml
@@ -9,12 +9,33 @@
         <root
             jcr:primaryType="nt:unstructured"
             sling:resourceType="wcm/foundation/components/responsivegrid">
+            <experiencefragment-header
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="${appId}/components/experiencefragment"
+                #if ( $singleCountry == "n" )
+                fragmentVariationPath="/content/experience-fragments/${appId}/language-masters/${language}/site/header/master"/>
+                #else
+                fragmentVariationPath="/content/experience-fragments/${appId}/${country}/${language}/site/header/master"/>
+                #end
+
+
             <responsivegrid
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="wcm/foundation/components/responsivegrid"
                 editable="{Boolean}true">
                 <cq:responsive jcr:primaryType="nt:unstructured"/>
             </responsivegrid>
+
+            <experiencefragment-footer
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="${appId}/components/experiencefragment"
+            #if ( $singleCountry == "n" )
+            fragmentVariationPath="/content/experience-fragments/${appId}/language-masters/${language}/site/footer/master"/>
+            #else
+            fragmentVariationPath="/content/experience-fragments/${appId}/${country}/${language}/site/footer/master"/>
+            #end
+
+
         </root>
         <cq:responsive jcr:primaryType="nt:unstructured">
             <breakpoints jcr:primaryType="nt:unstructured">

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__appId__/settings/wcm/templates/xf-web-variation/policies/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__appId__/settings/wcm/templates/xf-web-variation/policies/.content.xml
@@ -2,7 +2,11 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
     jcr:primaryType="cq:Page">
     <jcr:content
+#if ( $isSpaProject )
+        cq:policy="${appId}/components/spa/default"
+#else
         cq:policy="${appId}/components/page/policy"
+#end
         jcr:primaryType="nt:unstructured"
         sling:resourceType="wcm/core/components/policies/mappings">
         <root

--- a/src/main/archetype/ui.frontend.angular/src/app/components/import-components.ts
+++ b/src/main/archetype/ui.frontend.angular/src/app/components/import-components.ts
@@ -33,12 +33,16 @@ import {AccordionV1Component} from '@adobe/aem-core-components-angular-spa/conta
 import {TabsV1Component} from '@adobe/aem-core-components-angular-spa/containers/tabs/v1';
 
 import {LanguageNavigationV1Component} from '@adobe/aem-core-components-angular-base/layout/language-navigation/v1';
+import {ContainerV1Component, ContainerIsEmptyFn} from "@adobe/aem-core-components-angular-spa";
 
 /**
  * Normal MapTo - maps angular components to aem models
  */
 MapTo('${appId}/components/navigation')(NavigationV1Component, {isEmpty: NavigationV1IsEmptyFn});
 MapTo('${appId}/components/separator')(SeparatorV1Component);
+
+MapTo('${appId}/components/container')(ContainerV1Component, {isEmpty: ContainerIsEmptyFn});
+MapTo('${appId}/components/components/experiencefragment')(ContainerV1Component, {isEmpty: ContainerIsEmptyFn});
 
 MapTo('${appId}/components/download')(DownloadV1Component,{isEmpty: DownloadV1IsEmptyFn});
 MapTo('${appId}/components/languagenavigation')(LanguageNavigationV1Component);

--- a/src/main/archetype/ui.frontend.angular/src/app/components/import-components.ts
+++ b/src/main/archetype/ui.frontend.angular/src/app/components/import-components.ts
@@ -33,7 +33,8 @@ import {AccordionV1Component} from '@adobe/aem-core-components-angular-spa/conta
 import {TabsV1Component} from '@adobe/aem-core-components-angular-spa/containers/tabs/v1';
 
 import {LanguageNavigationV1Component} from '@adobe/aem-core-components-angular-base/layout/language-navigation/v1';
-import {ContainerV1Component, ContainerIsEmptyFn} from "@adobe/aem-core-components-angular-spa";
+import {ContainerV1Component} from '@adobe/aem-core-components-angular-spa/containers/container/v1';
+import {ContainerIsEmptyFn} from '@adobe/aem-core-components-angular-spa/core';
 
 /**
  * Normal MapTo - maps angular components to aem models

--- a/src/main/archetype/ui.frontend.angular/src/app/components/import-components.ts
+++ b/src/main/archetype/ui.frontend.angular/src/app/components/import-components.ts
@@ -43,7 +43,7 @@ MapTo('${appId}/components/navigation')(NavigationV1Component, {isEmpty: Navigat
 MapTo('${appId}/components/separator')(SeparatorV1Component);
 
 MapTo('${appId}/components/container')(ContainerV1Component, {isEmpty: ContainerIsEmptyFn});
-MapTo('${appId}/components/components/experiencefragment')(ContainerV1Component, {isEmpty: ContainerIsEmptyFn});
+MapTo('${appId}/components/experiencefragment')(ContainerV1Component, {isEmpty: ContainerIsEmptyFn});
 
 MapTo('${appId}/components/download')(DownloadV1Component,{isEmpty: DownloadV1IsEmptyFn});
 MapTo('${appId}/components/languagenavigation')(LanguageNavigationV1Component);

--- a/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -239,7 +239,8 @@ def cleanUpFrontendModule(frontendModules, optionFrontendModule, rootPom, rootDi
     // Not generating SPA: Delete SPA-specific files
     if (optionFrontendModule != "angular" && optionFrontendModule != "react") {
         // Delete app component
-        assert new File("$appsFolder/components/structure/spa").deleteDir()
+        assert new File("$appsFolder/components/spa").deleteDir()
+        assert new File("$appsFolder/components/xfpage/body.html").delete()
 
         // Delete EditConfigs
         assert new File("$appsFolder/components/text/_cq_editConfig.xml").delete()
@@ -255,6 +256,8 @@ def cleanUpFrontendModule(frontendModules, optionFrontendModule, rootPom, rootDi
         // Delete SPA content
         assert new File("$contentFolder/us/en/home").deleteDir()
 
+    }else{
+        assert new File("$appsFolder/components/xfpage/content.html").delete()
     }
 
     //cleanup SSR related files / folders when not choosing react (only react is supported for now) or not choosing SSR

--- a/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -239,7 +239,7 @@ def cleanUpFrontendModule(frontendModules, optionFrontendModule, rootPom, rootDi
     // Not generating SPA: Delete SPA-specific files
     if (optionFrontendModule != "angular" && optionFrontendModule != "react") {
         // Delete app component
-        assert new File("$appsFolder/components/spa").deleteDir()
+        assert new File("$appsFolder/components/structure/spa").deleteDir()
         assert new File("$appsFolder/components/xfpage/body.html").delete()
 
         // Delete EditConfigs


### PR DESCRIPTION
Integrate the latest changes in the spa core, to provide experience fragments OOTB, also in the SPA editor.

## Related Issue

https://github.com/adobe/aem-project-archetype/issues/744

## Motivation and Context

Partners are struggeling with the SPA editor + Experience Fragments. It's possible but requires some hacking.
This bootstraps now along with the new SPA core updates provides a clean solution OOTB.

## How Has This Been Tested?

Tested this locally against live AEM instances on:

Angular
React
General (making sure the normal project doesn't break)

## Screenshots (if appropriate):

![Screenshot 2021-06-25 at 08 18 24](https://user-images.githubusercontent.com/26429828/123388021-a8487c00-d598-11eb-8374-6d391f4239e7.png)

![Screenshot 2021-06-25 at 08 19 18](https://user-images.githubusercontent.com/26429828/123388059-b0a0b700-d598-11eb-924f-75a94d0da5a3.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:


- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.