### PR TITLE
Revert "chore: fix frontend general watch script"

### DIFF
--- a/src/main/archetype/ui.frontend.general/README.md
+++ b/src/main/archetype/ui.frontend.general/README.md
@@ -28,7 +28,6 @@ The following npm scripts drive the frontend workflow:
 * `npm run dev` - Full build of client libraries with JS optimization disabled (tree shaking, etc) and source maps enabled and CSS optimization disabled.
 * `npm run prod` - Full build of client libraries build with JS optimization enabled (tree shaking, etc), source maps disabled and CSS optimization enabled.
 * `npm run start` - Starts a static webpack development server for local development with minimal dependencies on AEM.
-* `npm run watch` - Runs webpack and slings the bundled clientlib to a local AEM instance when a change is made.
 
 ${hash}${hash}${hash} General
 

--- a/src/main/archetype/ui.frontend.general/package.json
+++ b/src/main/archetype/ui.frontend.general/package.json
@@ -13,8 +13,8 @@
     "dev": "webpack -d --env dev --config ./webpack.dev.js && clientlib --verbose",
     "prod": "webpack -p --config ./webpack.prod.js && clientlib --verbose",
     "start": "webpack-dev-server --open --config ./webpack.dev.js",
-    "sync": "aemsync -p ../ui.apps/src/main/content/jcr_root/apps/${appId}/clientlibs",
-    "watch": "webpack-dev-server --config ./webpack.dev.js --env.writeToDisk"
+    "sync": "aemsync -d -p ../ui.apps/src/main/content",
+    "watch": "webpack-dev-server --config ./webpack.dev.js --env.writeToDisk & watch 'clientlib' ./dist & aemsync -w ../ui.apps/src/main/content"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
@@ -50,8 +50,7 @@
     "webpack": "^4.27.1",
     "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^3.9.0",
-    "webpack-merge": "^4.2.1",
-    "webpack-shell-plugin": "^0.5.0"
+    "webpack-merge": "^4.2.1"
   },
   "dependencies": {},
   "browserslist": [

--- a/src/main/archetype/ui.frontend.general/webpack.dev.js
+++ b/src/main/archetype/ui.frontend.general/webpack.dev.js
@@ -1,30 +1,22 @@
-const merge              = require('webpack-merge');
-const common             = require('./webpack.common.js');
-const path               = require('path');
-const HtmlWebpackPlugin  = require('html-webpack-plugin');
-const WebpackShellPlugin = require('webpack-shell-plugin');
+const merge             = require('webpack-merge');
+const common            = require('./webpack.common.js');
+const path              = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 const SOURCE_ROOT = __dirname + '/src/main/webpack';
 
 module.exports = env => {
     const writeToDisk = env && Boolean(env.writeToDisk);
-    const plugins = [
-      new HtmlWebpackPlugin({
-        template: path.resolve(__dirname, SOURCE_ROOT + '/static/index.html')
-      })
-    ];
-
-    writeToDisk && plugins.push(
-      new WebpackShellPlugin({
-        onBuildExit:['clientlib && npm run sync']
-      })
-    );
 
     return merge(common, {
         mode: 'development',
         devtool: 'inline-source-map',
         performance: { hints: 'warning' },
-        plugins,
+        plugins: [
+            new HtmlWebpackPlugin({
+                template: path.resolve(__dirname, SOURCE_ROOT + '/static/index.html')
+            })
+        ],
         devServer: {
             inline: true,
             proxy: [{


### PR DESCRIPTION
Reverts adobe/aem-project-archetype#688

- This doesn't seem to work on MacOs / linux.
Will need to be tested cross-platform