### PR TITLE
Don't include adobe-public profile for cloud service

### DIFF
--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -447,6 +447,7 @@ Bundle-DocURL:
     </build>
 
     <profiles>
+#if ( $aemVersion != "cloud" )
         <!-- ====================================================== -->
         <!-- A D O B E P U B L I C P R O F I L E -->
         <!-- ====================================================== -->
@@ -494,6 +495,7 @@ Bundle-DocURL:
             </pluginRepositories>
         </profile>
 
+#end
         <!-- Development profile: install only the bundle -->
         <profile>
             <id>autoInstallBundle</id>

--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -922,7 +922,7 @@ Bundle-DocURL:
                 <groupId>io.wcm</groupId>
                 <artifactId>io.wcm.testing.aem-mock.junit5</artifactId>
 #if ( $aemVersion != "cloud" )
-                <version>3.0.2</ersion>
+                <version>3.0.2</version>
 #else
                 <version>4.1.0</version>
 #end

--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -921,7 +921,11 @@ Bundle-DocURL:
             <dependency>
                 <groupId>io.wcm</groupId>
                 <artifactId>io.wcm.testing.aem-mock.junit5</artifactId>
-                <version>3.0.2</version>
+#if ( $aemVersion != "cloud" )
+                <version>3.0.2</ersion>
+#else
+                <version>4.1.0</version>
+#end
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
See #752  - this profile is not necessary for cloud service anymore, therefore it should be removed

## Description

Make the profile optional

## Related Issue

See #752 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.