### PR TITLE
Update to aemanalyser-maven-plugin 1.1.2

### DIFF
--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -103,7 +103,7 @@
 #end
 #if ( $aemVersion == "cloud")
         <aem.sdk.api>SDK_VERSION</aem.sdk.api>
-        <aemanalyser.version>1.0.10</aemanalyser.version>
+        <aemanalyser.version>1.1.2</aemanalyser.version>
 #end
         <componentGroupName>$appTitle</componentGroupName>
     </properties>


### PR DESCRIPTION
This fixes a johnzon-core JSON parsing issue:
https://github.com/adobe/aemanalyser-maven-plugin/issues/91