### PR TITLE
#798 Introduce Core Components Plugin for AEM Mocks & Update AEM Mocks

### DIFF
--- a/src/main/archetype/core/pom.xml
+++ b/src/main/archetype/core/pom.xml
@@ -170,6 +170,11 @@ Import-Package: javax.annotation;version=0.0.0,*
             <groupId>com.adobe.aem</groupId>
             <artifactId>aem-sdk-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.adobe.cq</groupId>
+            <artifactId>core.wcm.components.core</artifactId>
+            <scope>test</scope>
+        </dependency>
 #end
 
 #if ( $includeCommerce == "y" )
@@ -233,16 +238,11 @@ Import-Package: javax.annotation;version=0.0.0,*
         <dependency>
             <groupId>io.wcm</groupId>
             <artifactId>io.wcm.testing.aem-mock.junit5</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.sling</groupId>
-                    <artifactId>org.apache.sling.models.impl</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-simple</artifactId>
-                </exclusion>
-            </exclusions>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.adobe.cq</groupId>
+            <artifactId>core.wcm.components.testing.aem-mock-plugin</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- Required to be able to support injection with @Self and @Via -->

--- a/src/main/archetype/core/src/test/java/core/models/HelloWorldModelTest.java
+++ b/src/main/archetype/core/src/test/java/core/models/HelloWorldModelTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import com.day.cq.wcm.api.Page;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import ${package}.core.testcontext.AppAemContext;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -34,13 +35,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(AemContextExtension.class)
 class HelloWorldModelTest {
 
+    private final AemContext context = AppAemContext.newAemContext();
+
     private HelloWorldModel hello;
 
     private Page page;
     private Resource resource;
 
     @BeforeEach
-    public void setup(AemContext context) throws Exception {
+    public void setup() throws Exception {
 
         // prepare a page with a test resource
         page = context.create().page("/content/mypage");

--- a/src/main/archetype/core/src/test/java/core/testcontext/AppAemContext.java
+++ b/src/main/archetype/core/src/test/java/core/testcontext/AppAemContext.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright 2021 Adobe Systems Incorporated
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package ${package}.core.testcontext;
+
+import static com.adobe.cq.wcm.core.components.testing.mock.ContextPlugins.CORE_COMPONENTS;
+
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextBuilder;
+import io.wcm.testing.mock.aem.junit5.AemContextCallback;
+
+/**
+ * Sets up {@link AemContext} for unit tests in this application.
+ */
+public final class AppAemContext {
+
+    private AppAemContext() {
+        // static methods only
+    }
+
+    /**
+     * @return {@link AemContext}
+     */
+    public static AemContext newAemContext() {
+        return new AemContextBuilder()
+                .plugin(CORE_COMPONENTS)
+                .afterSetUp(SETUP_CALLBACK)
+                .build();
+    }
+
+    /**
+     * Custom set up rules required in all unit tests.
+     */
+    private static final AemContextCallback SETUP_CALLBACK = new AemContextCallback() {
+        @Override
+        public void execute(AemContext context) {
+            // custom project initialization code for every unit test
+        }
+    };
+
+}

--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -69,9 +69,7 @@
         <aio.runtime.namespace>${env.AIO_RUNTIME_NAMESPACE}</aio.runtime.namespace>
         <aio.runtime.auth>${env.AIO_RUNTIME_AUTH}</aio.runtime.auth>
 #end
-#if ( $aemVersion != "cloud" || $includeExamples == "y")
-        <core.wcm.components.version>2.17.2</core.wcm.components.version>
-#end
+        <core.wcm.components.version>2.17.10</core.wcm.components.version>
 #if ( $includeCommerce == "y" )
         <core.cif.components.version>2.1.0</core.cif.components.version>
         <magento.graphql.version>9.0.0-magento242ee</magento.graphql.version>
@@ -796,6 +794,11 @@ Bundle-DocURL:
                 <version>${aem.sdk.api}</version>
                 <scope>provided</scope>
             </dependency>
+            <dependency>
+                <groupId>com.adobe.cq</groupId>
+                <artifactId>core.wcm.components.core</artifactId>
+                <version>${core.wcm.components.version}</version>
+            </dependency>
 #end
 #if ( $includeExamples == "y" )
             <dependency>
@@ -921,11 +924,13 @@ Bundle-DocURL:
             <dependency>
                 <groupId>io.wcm</groupId>
                 <artifactId>io.wcm.testing.aem-mock.junit5</artifactId>
-#if ( $aemVersion != "cloud" )
-                <version>3.0.2</version>
-#else
-                <version>4.1.0</version>
-#end
+                <version>4.1.2</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.adobe.cq</groupId>
+                <artifactId>core.wcm.components.testing.aem-mock-plugin</artifactId>
+                <version>${core.wcm.components.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Fixes #798 

This PR depends on #796 because the plugin for AEM mocks was first released in Core Components 2.17.10

* Introduce Core Components Plugin for AEM Mocks
* this requires to always set a property core.wcm.components.version and include the core.wcm.components.core dependency - for cloud projects it's only required in "test" scope to have the model implementation classes available in the test classpath
* update to AEM Mocks 4.1.2 for both cloud and non-cloud projects
* remove obsolete dependencies exclusions for AEM Mocks
* introduce a test context class `AppAemContext` as example to prepare test setup logic required for every unit test in the project
