### PR TITLE
Disable access to default CGI scripts

### DIFF
--- a/src/main/archetype/dispatcher.cloud/src/conf.d/dispatcher_vhost.conf
+++ b/src/main/archetype/dispatcher.cloud/src/conf.d/dispatcher_vhost.conf
@@ -95,6 +95,7 @@ Include conf.d/variables/global.vars
 # Disable access to default CGI scripts
 <Directory "/var/www/localhost/cgi-bin">
     AllowOverride None
+    Options None
     Require all denied
 </Directory>
 

--- a/src/main/archetype/dispatcher.cloud/src/conf.d/dispatcher_vhost.conf
+++ b/src/main/archetype/dispatcher.cloud/src/conf.d/dispatcher_vhost.conf
@@ -92,6 +92,12 @@ Include conf.d/variables/global.vars
 	</LocationMatch>
 </IfDefine>
 
+# Disable access to default CGI scripts
+<Directory "/var/www/localhost/cgi-bin">
+    AllowOverride None
+    Require all denied
+</Directory>
+
 Include conf.d/enabled_vhosts/*.vhost
 
 # Create a catch-all vhost


### PR DESCRIPTION
Disable access to default CGI scripts delivered with Alpine's `apache2` package.

## Description

Alpine Linux [apache2](https://pkgs.alpinelinux.org/package/edge/main/x86_64/apache2) package contains [a few sample files](https://pkgs.alpinelinux.org/contents?file=&path=%2Fvar%2F*&name=apache2&branch=edge&repo=main&arch=x86_64) that get installed in `/var/www` directory. 

[httpd.conf](https://pkgs.alpinelinux.org/contents?file=httpd.conf&path=&name=apache2&branch=edge&repo=main&arch=x86_64) opens up access to `/var/www/localhost/cgi-bin/` directory:

```
<IfModule alias_module>
    ScriptAlias /cgi-bin/ "/var/www/localhost/cgi-bin/"
</IfModule>
<Directory "/var/www/localhost/cgi-bin">
    AllowOverride None
    Options None
    Require all granted
</Directory>
```

That means you can go to `/cgi-bin/printenv` (or other files I linked to above) in order to get access to `/var/www/localhost/cgi-bin/printenv` from the filesystem.

## Related Issue

Adobe support ticket: E-000447857

## Motivation and Context

Default configuration should limit the access just to a very few directories that are absolutely required. At the time of writing that seems to be:
* `${DOCROOT}` (`/mnt/var/www/html`) - dispatcher cache directory
* `/var/www/localhost/htdocs` referenced by `unmatched-host-catch-all` vhost in `dispatcher_vhost.conf` file

Caveats:
* `<Directory>` directive introduced in this PR can be overwritten (see [this](https://httpd.apache.org/docs/2.4/misc/security_tips.html#protectserverfiles)), so ideally `/var/www/localhost/cgi-bin` should be removed at container build time. It doesn't change the fact that default configuration delivered with the archetype should be as secure as possible
* if given directory exists, but Apache doesn't have access to it then 403 is generated. If the directory is gone then 404 comes back. To be determined if that's the right behaviour
* dispatcher filters don't protect from that, as `ScriptAlias` kicks in much earlier in the flow (`/cgi-bin/*` requests are not even processed by `mod_dispatcher`)

## How Has This Been Tested?

AEM SDK version: `2021.9.5800.20210903T095431Z-210800`

Current state: https://gist.github.com/jwadolowski/4e5b315ac7d87f291c87decafd9094ed

New state:
```
$ curl http://localhost:8080/cgi-bin/printenv -SsD -
HTTP/1.1 403 Forbidden
Date: Wed, 15 Sep 2021 12:17:03 GMT
Server: Apache
X-Frame-Options: SAMEORIGIN
Content-Length: 199
Content-Type: text/html; charset=iso-8859-1

<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>403 Forbidden</title>
</head><body>
<h1>Forbidden</h1>
<p>You don't have permission to access this resource.</p>
</body></html>
```

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.