### PR TITLE
Solved problem with components path

### DIFF
--- a/src/main/archetype/ui.frontend.general/src/main/webpack/site/main.ts
+++ b/src/main/archetype/ui.frontend.general/src/main/webpack/site/main.ts
@@ -3,5 +3,5 @@
 import "./main.scss";
 
 // Javascript or Typescript
-import "./**/*.js";
-import "./**/*.ts";
+import "../components/**/*.js";
+import "../components/**/*.ts";


### PR DESCRIPTION
## Description

Currently js or ts files inside src/main/webpack/components folder are not being compiled correctly because of this issue.

Another option is going up one level in path:
```
// Stylesheets
import "./main.scss";

// Javascript or Typescript
import "../**/*.js";
import "../**/*.ts";
```
## Motivation and Context

It allows js and ts files to compile correctly when using package.json scripts like `npm run watch`

## Types of changes

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.