### PR TITLE
CQ-4312433 fixed data source test failing in firefox

### DIFF
--- a/src/main/archetype/ui.tests/test-module/lib/util/forms.selectors.js
+++ b/src/main/archetype/ui.tests/test-module/lib/util/forms.selectors.js
@@ -10,6 +10,7 @@ var selectors = {
             authenticationTab : 'coral-tab=Authentication Settings',
             title : '[name="./jcr:title"]',
             authenticationSelector : '[name="./selectAuthentication"]',
+            authenticationSelectorInput : 'input[name="./selectAuthentication"]',
             oAuthUrl : '[name="./oAuthUrl"]',
             refreshTokenUrl : '[name="./refresh_token_uri"]',
             accessTokenUrl : '[name="./access_token_uri"]',

--- a/src/main/archetype/ui.tests/test-module/specs/aem/forms.js
+++ b/src/main/archetype/ui.tests/test-module/specs/aem/forms.js
@@ -68,7 +68,7 @@ describe('AEM Forms OOTB Content Tests', () => {
 
                 //Verify OAuth authentication mechanism selected
                 expect($(selectors.editor.dataSourceEditor.authenticationSelector)).toBeDisplayed();
-                expect($(selectors.editor.dataSourceEditor.authenticationSelector).getValue()).toEqual('OAuth 2.0');
+                expect($(selectors.editor.dataSourceEditor.authenticationSelectorInput).getValue()).toEqual('OAuth 2.0');
 
                 //Verify Auth url not empty
                 expect($(selectors.editor.dataSourceEditor.oAuthUrl)).toBeDisplayed();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed FDM data source tests failing in firefox browser
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
wdio getValue function on a coral-select element is returning null in firefox browser and element value in chrome browser.
causing test to fail in firefox browser. changing tests to get value from input element inside coral-select.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
verified tests in chrome, firefox browser (with and without headless) in docker and local execution.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.