### PR TITLE
Sync dispatcher SDK v2.0.65 config with the archetype

### DIFF
--- a/src/main/archetype/dispatcher.cloud/src/conf.d/dispatcher_vhost.conf
+++ b/src/main/archetype/dispatcher.cloud/src/conf.d/dispatcher_vhost.conf
@@ -10,6 +10,14 @@ ServerName dispatcher
 Include conf.d/variables/default.vars
 Include conf.d/variables/global.vars
 
+#SKYOPS-13837: Proxy static frontend code requests through dispatcher
+<IfDefine FRONTEND_SUPPORT>
+    SSLProxyEngine on
+    <LocationMatch "/libs/cq/frontend-static">
+        RewriteRule "^/mnt/var/www/html/libs/cq/frontend-static(/[^\.].*)$" "%{env:FRONTEND_URI_PREFIX}$1?%{env:FRONTEND_URI_SUFFIX}" [P,L]
+    </LocationMatch>
+</IfDefine>
+
 # CQ-4315090: Allow the functional replication to access publish instance directly for dev and stage environments
 <IfDefine ENVIRONMENT_DEV>
     <LocationMatch "/content/test-site/">


### PR DESCRIPTION
Sync of immutable files from the SDK v2.0.65 to the archetype 

## Description

In order to keep `validator.sh` happy all dispatcher config differences have been synced to the archetype. 

## Related Issue

N/A

## Motivation and Context

```
$ $AEM_SDK_DISPATCHER_TOOLS_LATEST/dispatcher-sdk-2.0.65/bin/validate.sh dispatcher/src
...
Phase 2 finished
Phase 3: Immutability check
empty mode param, assuming mode = 'check'
running in 'check' mode
running in 'check' mode
reading immutable file list from /etc/httpd/immutable.files.txt
checking 'conf.d/available_vhosts/default.vhost' immutability (if present)
checking existing 'conf.d/available_vhosts/default.vhost' for changes
checking 'conf.d/dispatcher_vhost.conf' immutability (if present)
replacing include directive in 'conf.d/dispatcher_vhost.conf' before proceeding
checking existing 'conf.d/dispatcher_vhost.conf' for changes
immutable file 'conf.d/dispatcher_vhost.conf' has been changed:
--- /etc/httpd/conf.d/dispatcher_vhost.conf
+++ /etc/httpd-actual/conf.d/dispatcher_vhost.conf
@@ -10,14 +10,6 @@
 Include conf.d/variables/default.vars
 Include conf.d/variables/global.vars

-#SKYOPS-13837: Proxy static frontend code requests through dispatcher
-<IfDefine FRONTEND_SUPPORT>
-    SSLProxyEngine on
-    <LocationMatch "/libs/cq/frontend-static">
-        RewriteRule "^/mnt/var/www/html/libs/cq/frontend-static(/[^\.].*)$" "%{env:FRONTEND_URI_PREFIX}$1?%{env:FRONTEND_URI_SUFFIX}" [P,L]
-    </LocationMatch>
-</IfDefine>
-
 # CQ-4315090: Allow the functional replication to access publish instance directly for dev and stage environments
 <IfDefine ENVIRONMENT_DEV>
     <LocationMatch "/content/test-site/">
** error: immutable file 'conf.d/dispatcher_vhost.conf' has been changed!
```

## How Has This Been Tested?

* generate new project from the archetype

```
$ mvn -B archetype:generate \
 -D archetypeGroupId=com.adobe.aem \
 -D archetypeArtifactId=aem-project-archetype \
 -D archetypeVersion=30 \
 -D appTitle="My Site" \
 -D appId="mysite-v30" \
 -D groupId="com.mysite
```

* copy the file from the SDK to newly generated project: `cp $AEM_SDK_DISPATCHER_TOOLS_LATEST/dispatcher-sdk-2.0.65/src/conf.d/dispatcher_vhost.conf mysite-v30/dispatcher/src/conf.d/dispatcher_vhost.conf`
* re-run the validator
```
$ $AEM_SDK_DISPATCHER_TOOLS_LATEST/dispatcher-sdk-2.0.65/bin/validate.sh mysite-v30/dispatcher/src
...
no immutable file has been changed - check is SUCCESSFUL
Phase 3 finished
```

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.