### PR TITLE
Adding .gitattributes to archetype-metadata.xml. Fixes #825.

### DIFF
--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -543,6 +543,7 @@
         <include>README-CIF.md</include>
         <include>README-precompiled-scripts.md</include>
         <include>.gitignore</include>
+        <include>.gitattributes</include>
         <include>LICENSE</include>
       </includes>
     </fileSet>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding .gitattributes to archetype-metadata.xml. File previously added in #661 but missing from new projects when using the `mvn -B archetype:generate` command.

## Related Issue
* Relates to #661 
* Fixes #825 

## Motivation and Context

In certain development environments that may be configured with different GIT line ending configurations, it is possible for developers to unwillingly commit files with invalid line endings which will break the Dispatcher module's immutable file check due to invalid MD5 hashes.

## How Has This Been Tested?
Yes. Steps included:
* Adding changes locally
* Building archetype project with `mvn clean install -Pit-basic`
* Run `mvn -B archetype:generate ... -DarchetypeVersion=31-SNAPSHOT`
* Confirm presence of `.gitattributes` in new project 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.