### PR TITLE
ui.tests module should use a specified version of Node JS in the Docker container

### DIFF
--- a/src/main/archetype/ui.tests/Dockerfile
+++ b/src/main/archetype/ui.tests/Dockerfile
@@ -15,7 +15,7 @@
 #
 # DO NOT MODIFY
 #
-FROM node:lts-slim
+FROM node:14-slim
 
 ENV APP_PATH /usr/src/app
 ENV SELENIUM_STARTUP_TIMEOUT 60


### PR DESCRIPTION
* Changed to specified Node version

Closes #828
