### PR TITLE
Remove reference to legacy foundation components

### DIFF
--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/components/accordion/new/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/components/accordion/new/.content.xml
@@ -20,6 +20,6 @@
           cq:icon="panel"
           jcr:primaryType="cq:Component"
           jcr:title="New Paragraph - Accordion"
-          sling:resourceSuperType="wcm/foundation/components/parsys/newpar"/>
+          sling:resourceSuperType="core/wcm/components/container/v1/container/new"/>
         
         

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/components/carousel/new/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/components/carousel/new/.content.xml
@@ -19,6 +19,6 @@
           cq:icon="panel"
           jcr:primaryType="cq:Component"
           jcr:title="New Paragraph - Carousel"
-          sling:resourceSuperType="wcm/foundation/components/parsys/newpar"/>
+          sling:resourceSuperType="core/wcm/components/container/v1/container/new"/>
         
         

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/components/container/new/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/components/container/new/.content.xml
@@ -19,6 +19,6 @@
           cq:icon="panel"
           jcr:primaryType="cq:Component"
           jcr:title="New Paragraph - Container"
-          sling:resourceSuperType="wcm/foundation/components/parsys/newpar"/>
+          sling:resourceSuperType="core/wcm/components/container/v1/container/new"/>
         
         

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/components/tabs/new/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/components/tabs/new/.content.xml
@@ -19,6 +19,6 @@
           cq:icon="panel"
           jcr:primaryType="cq:Component"
           jcr:title="New Paragraph - Tabs"
-          sling:resourceSuperType="wcm/foundation/components/parsys/newpar"/>
+          sling:resourceSuperType="core/wcm/components/container/v1/container/new"/>
         
         


### PR DESCRIPTION
- switched superType of wcm/foundation/components/parsys/newpar to core/wcm/components/container/v1/container/new

fixes #772

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.