### PR TITLE
Added default cache rule for assets

### DIFF
--- a/src/main/archetype/dispatcher.cloud/src/conf.d/available_vhosts/default.vhost
+++ b/src/main/archetype/dispatcher.cloud/src/conf.d/available_vhosts/default.vhost
@@ -62,4 +62,8 @@ Include conf.d/variables/custom.vars
 		RewriteRule "^(/?)$" "/index.html" [PT]
 
 	</IfModule>
+	# Set Cache-Control header for assets
+	<LocationMatch "^/content/dam/.*\.(gif|jpeg|jpg|js|mov|png|svg|txt|zip|webp|jpf|avif)$">
+        	Header set Cache-Control "max-age=60,s-maxage=86400,stale-while-revalidate=21600,stale-if-error=86400"
+    	</LocationMatch>
 </VirtualHost>


### PR DESCRIPTION
Currently, we don't cache assets OOTB, adding a config to start caching images.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.