### PR TITLE
#847 Update AEM Mocks and other testing dependencies

### DIFF
--- a/src/main/archetype/core/pom.xml
+++ b/src/main/archetype/core/pom.xml
@@ -245,6 +245,11 @@ Import-Package: javax.annotation;version=0.0.0,*
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.caconfig-mock-plugin</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.adobe.cq</groupId>
             <artifactId>core.wcm.components.testing.aem-mock-plugin</artifactId>
             <scope>test</scope>

--- a/src/main/archetype/core/src/test/java/core/testcontext/AppAemContext.java
+++ b/src/main/archetype/core/src/test/java/core/testcontext/AppAemContext.java
@@ -16,6 +16,9 @@
 package ${package}.core.testcontext;
 
 import static com.adobe.cq.wcm.core.components.testing.mock.ContextPlugins.CORE_COMPONENTS;
+import static org.apache.sling.testing.mock.caconfig.ContextPlugins.CACONFIG;
+
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
 
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextBuilder;
@@ -34,10 +37,24 @@ public final class AppAemContext {
      * @return {@link AemContext}
      */
     public static AemContext newAemContext() {
+        return newAemContextBuilder().build();
+    }
+
+    /**
+     * @return {@link AemContextBuilder}
+     */
+    public static AemContextBuilder newAemContextBuilder() {
+        return newAemContextBuilder(ResourceResolverType.RESOURCERESOLVER_MOCK);
+    }
+
+    /**
+     * @return {@link AemContextBuilder}
+     */
+    public static AemContextBuilder newAemContextBuilder(ResourceResolverType resourceResolverType) {
         return new AemContextBuilder()
+                .plugin(CACONFIG)
                 .plugin(CORE_COMPONENTS)
-                .afterSetUp(SETUP_CALLBACK)
-                .build();
+                .afterSetUp(SETUP_CALLBACK);
     }
 
     /**

--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -909,20 +909,20 @@ Bundle-DocURL:
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.6.2</version>
+                <version>5.8.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>3.3.3</version>
+                <version>4.1.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-junit-jupiter</artifactId>
-                <version>3.3.3</version>
+                <version>4.1.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -934,8 +934,13 @@ Bundle-DocURL:
             <dependency>
                 <groupId>io.wcm</groupId>
                 <artifactId>io.wcm.testing.aem-mock.junit5</artifactId>
-                <version>4.1.2</version>
+                <version>4.1.8</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.sling</groupId>
+                <artifactId>org.apache.sling.testing.caconfig-mock-plugin</artifactId>
+                <version>1.3.6</version>
             </dependency>
             <dependency>
                 <groupId>com.adobe.cq</groupId>


### PR DESCRIPTION
Fixes #847 

* Update to latest AEM Mocks version (which includes some important updates from sling-mocks osgi-mock)
* include Sling Context-Aware Configuration plugin to test code which uses context-aware configuration
* refactor AppAemContext a bit to make it easier to test with different resource resolver types
* also update JUnit and Mockito testing dependencies
