### PR TITLE
Upgrade aem-cloud-testing-clients to v1.0.0

### DIFF
--- a/src/main/archetype/it.tests/pom.xml
+++ b/src/main/archetype/it.tests/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>com.adobe.cq</groupId>
             <artifactId>aem-cloud-testing-clients</artifactId>
-            <version>0.2.4</version>
+            <version>1.0.0</version>
         </dependency>
 #elseif ($aemVersion.startsWith("6.5"))
         <dependency>


### PR DESCRIPTION
Upgrade aem-cloud-testing-clients to v1.0.0, which includes the fixes for CVE-2021-20190 and CVE-2016-6798.