### PR TITLE
fix(glob-import-loader): latest version fixes circular dependency

### DIFF
--- a/src/main/archetype/ui.frontend.general/package.json
+++ b/src/main/archetype/ui.frontend.general/package.json
@@ -35,7 +35,7 @@
     "cssnano": "^5.0.12",
     "eslint": "^8.4.1",
     "eslint-webpack-plugin": "^3.1.1",
-    "glob-import-loader": "^1.1.4",
+    "glob-import-loader": "^1.2.0",
     "html-webpack-plugin": "^5.5.0",
     "mini-css-extract-plugin": "^2.4.5",
     "postcss": "^8.2.15",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Upgrading mini-css-extract-plugin and webpack to latest version caused the builds (production and development) to break, 

mini-css-extract-plugin version: 2.4.5
webpack version: 5.65.0
<!--- Describe your changes in detail -->

## Related Issue

https://github.com/webpack-contrib/mini-css-extract-plugin/issues/733
https://github.com/webpack/webpack/issues/15060

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
I am using aem archetype on my current project and I decided to upgrade the npm packages as package.json seemed outdated. The upgrade was also necessary because after running `npm audit`, there were also some third party packages containing vulnerabilities.

Anyway, after upgrading everything, the production and development builds (`npm run prod` and `npm run dev`) did not work anymore.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
This is the repository I created https://github.com/kevinolivar/aem-test with the up-to-date package.json+audit. glob-import-loader is not updated to v1.2.0.

After upgrading it, I locally ran `mvn clean install -PautoInstallPackage` and other npm commands. All passed.

Also, I recently saw a PR merged (release/33) regarding upgrade/audit but haven't checked if this also occurs. Maybe not, otherwise the build would have failed.

I will double check actually because my package.json has only the following differences (+additional packages such as babel-loader) compared to the archetype release 33.

````
    "@typescript-eslint/eslint-plugin": "^5.8.0",
    "@typescript-eslint/parser": "^5.8.0",
    "acorn": "^8.6.0",
    "aemsync": "^4.0.1",
    "autoprefixer": "^10.4.0",
    "chokidar-cli": "^3.0.0",
    "clean-webpack-plugin": "^4.0.0",
    "copy-webpack-plugin": "^10.2.0",
    "css-minimizer-webpack-plugin": "^3.3.1",
    "eslint": "^8.5.0",
    "glob-import-loader": "^1.2.0",
    "postcss-loader": "^6.2.1",
    "sass": "^1.17.2",
    "style-loader": "^3.3.1",
    "terser-webpack-plugin": "^5.3.0",
    "typescript": "^4.5.4",
    "webpack-dev-server": "^4.7.1",
````

Maybe it make more sense to open this as an issue...?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.