### PR TITLE
#857 make compatible with maven-archetype-plugin 3.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     </developers>
 
     <properties>
-        <maven.archetype.version>3.1.2</maven.archetype.version>
+        <maven.archetype.version>3.2.1</maven.archetype.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -1,4 +1,3 @@
-@Grab(group="org.codehaus.groovy", module="groovy-all", version="2.4.8")
 import static groovy.io.FileType.*
 import groovy.util.XmlSlurper
 import java.nio.file.Path


### PR DESCRIPTION
maven-archetype-plugin 3.2.1 which contains "groovy-all" dependency by default

Fixes #857