### PR TITLE
Correct generated repoinit script

### DIFF
--- a/src/main/archetype/ui.config/src/main/content/jcr_root/apps/__appId__/osgiconfig/config/org.apache.sling.jcr.repoinit.RepositoryInitializer~__appId__.cfg.json
+++ b/src/main/archetype/ui.config/src/main/content/jcr_root/apps/__appId__/osgiconfig/config/org.apache.sling.jcr.repoinit.RepositoryInitializer~__appId__.cfg.json
@@ -2,9 +2,6 @@
     "scripts": [
         "create path (sling:OrderedFolder) /content/dam/${appId}",
         "create path (nt:unstructured) /content/dam/${appId}/jcr:content",
-        "set properties on /content/dam/${appId}/jcr:content",
-        "set cq:conf{String} to /conf/${appId}",
-        "set jcr:title{String} to \"${appTitle}\"",
-        "end"
+        "set properties on /content/dam/${appId}/jcr:content\n  set cq:conf{String} to /conf/${appId}\n  set jcr:title{String} to \"${appTitle}\"\nend"
     ]
 }


### PR DESCRIPTION
## Description

Generated repoinit script (`ui.config/src/main/content/jcr_root/apps/minimal/osgiconfig/config/org.apache.sling.jcr.repoinit.RepositoryInitializer~minimal.cfg.json`) on 6.5 and cloud looks like this:

```json
{
    "scripts": [
        "create path (sling:OrderedFolder) /content/dam/minimal",
        "create path (nt:unstructured) /content/dam/minimal/jcr:content",
        "set properties on /content/dam/minimal/jcr:content",
        "set cq:conf{String} to /conf/minimal",
        "set jcr:title{String} to \"Minimal\"",
        "end"
    ]
}
```

This PR merges the last four lines into a single script

```json
{
    "scripts": [
        "create path (sling:OrderedFolder) /content/dam/minimal",
        "create path (nt:unstructured) /content/dam/minimal/jcr:content",
        "set properties on /content/dam/minimal/jcr:content\n  set cq:conf{String} to /conf/minimal\n  set jcr:title{String} to \"Minimal\"\nend"
    ]
}
```

## Related Issue

#852 

## Motivation and Context

Solves the bug I've stumbled into with setting up a new project, turned out this is an open issue.

## How Has This Been Tested?

Generated a project from the changed archetype, installed it on fresh 6.5.11. Restarted AEM. This worked, and did not work with latest v34.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/1556664/149335612-08b2d00b-91d6-47b0-8843-c220512bcc81.png)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.