### PR TITLE
add rule to remove forms ui test assets if not a forms project

### DIFF
--- a/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -187,6 +187,7 @@ if (includeForms == "n" && includeFormsenrollment == "n" && includeFormscommunic
     assert new File("$uiTestPackage/test-module/specs/aem/forms.js").delete()
     assert new File("$uiTestPackage/test-module/lib/util").deleteDir()
     assert new File("$uiTestPackage/test-module/rules").deleteDir()
+    assert new File("$uiTestPackage/test-module/assets/form").deleteDir()
     assert new File("$appsFolder/clientlibs/clientlibs-forms").deleteDir()
 } else {
     if (aemVersion == "cloud") {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removes unused Forms assets from `ui.tests` module if **not** a Forms project

## Related Issue

Issue #874 

## Motivation and Context

When generating a vanilla AEM project there is no need to include 300+ images that are only for AEM Forms projects. FWIW including 300+ images for a Forms project seems excessive...but thats neither here nor there

## How Has This Been Tested?

Ran using `it-tests` profile and generated a non-forms project using the following command:

```
mvn -B org.apache.maven.plugins:maven-archetype-plugin:3.2.1:generate \
 -D archetypeGroupId=com.adobe.aem \
 -D archetypeArtifactId=aem-project-archetype \
 -D archetypeVersion=36-SNAPSHOT\
 -D appTitle="My Site" \
 -D appId="mysite" \
 -D groupId="com.mysite"
```

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.