### PR TITLE
Update package.json to add moment npm dependency that fails on Mac OS

### DIFF
--- a/src/main/archetype/ui.tests/test-module/package.json
+++ b/src/main/archetype/ui.tests/test-module/package.json
@@ -37,7 +37,8 @@
     "request-promise": "^4.2.6",
     "source-map-support": "^0.5.0",
     "tough-cookie": "^4.0.0",
-    "wdio-html-nice-reporter": "^7.9.1"
+    "wdio-html-nice-reporter": "^7.9.1",
+    "moment": "^2.29.1"
   },
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
Update package.json to add moment npm dependency that fails on Mac OS.

This issue was reported on https://github.com/adobe/aem-project-archetype/issues/891

npm was complaining on a dependency: [INFO] Error: Cannot find module 'moment' 

## Description

Added the latest moment npm dependency under the /ui.tests/test-module/package.json

"moment": "^2.29.1"

## Related Issue

https://github.com/adobe/aem-project-archetype/issues/891

## Motivation and Context

build failed when executing the tests when running the command:  mvn verify -Pui-tests-local-execution 

## How Has This Been Tested?

Tested this locally on two Macs

## Screenshots (if appropriate):

<img width="1392" alt="Screen Shot 2022-03-10 at 12 42 41 PM" src="https://user-images.githubusercontent.com/70654750/157751057-0726740f-cd19-4578-9587-4b9383b455a3.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.