### PR TITLE
[Frontend] upgrade aem-clientlib-generator to v1.8.0

### DIFF
--- a/src/main/archetype/ui.frontend.general/package-lock.json
+++ b/src/main/archetype/ui.frontend.general/package-lock.json
@@ -1032,12 +1032,12 @@
       "dev": true
     },
     "aem-clientlib-generator": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/aem-clientlib-generator/-/aem-clientlib-generator-1.7.7.tgz",
-      "integrity": "sha512-tdp3CtLsSsWQW0QZbQQsIO6ZvQ+AZ8KSdibEPZSM8BFvVgPkUAof+hRWfpzEyMk78Y/pJK0qQl7uq3DKkoaaUA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aem-clientlib-generator/-/aem-clientlib-generator-1.8.0.tgz",
+      "integrity": "sha512-XT+a6ujzwFbL/kGVCgrCxyh0W8+JmQnY1OU+MHJTp7L3bPR/2Jd2Y7JwpQKmYDE9FflPh1R1c6VcCsyc5Eu+rg==",
       "dev": true,
       "requires": {
-        "async": "3.2.0",
+        "async": "^3.2.3",
         "fs-extra": "9.0.1",
         "glob": "7.1.6",
         "lodash": "4.17.21",
@@ -1179,9 +1179,9 @@
       "dev": true
     },
     "async": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
       "dev": true
     },
     "asynckit": {

--- a/src/main/archetype/ui.frontend.general/package.json
+++ b/src/main/archetype/ui.frontend.general/package.json
@@ -23,7 +23,7 @@
     "@typescript-eslint/eslint-plugin": "^5.7.0",
     "@typescript-eslint/parser": "^5.7.0",
     "acorn": "^6.1.0",
-    "aem-clientlib-generator": "^1.4.3",
+    "aem-clientlib-generator": "^1.8.0",
     "aemsync": "^4.0.1",
     "autoprefixer": "^9.2.1",
     "browserslist": "^4.2.1",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A high severity issue was reported for [async](https://github.com/caolan/async), here https://github.com/advisories/GHSA-fwr7-v2mv-hh25
`aem-clientlib-generator` has `async` as dependencies and therefore, could also be potentially exposed to the vulnerability.

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/wcm-io-frontend/aem-clientlib-generator/issues/44
https://github.com/adobe/aem-project-archetype/issues/927

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Reduce the risk for `aem-clientlib-generator` to be affected by the Prototype Pollution in async.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.