### PR TITLE
SITES-3659 - [Odin] Review Dispatcher config for Odin and contribute generic parts - Persisted queries

### DIFF
--- a/src/main/archetype/dispatcher.cloud/src/conf.d/available_vhosts/default.vhost
+++ b/src/main/archetype/dispatcher.cloud/src/conf.d/available_vhosts/default.vhost
@@ -17,7 +17,6 @@ Include conf.d/variables/custom.vars
 	ServerAlias	 "*"
 	# Use a document root that matches the one in conf.dispatcher.d/default.farm
 	DocumentRoot "${DOCROOT}"
-	DispatcherNoCanonURL 1
 	# URI dereferencing algorithm is applied at Sling's level, do not decode parameters here
 	AllowEncodedSlashes NoDecode
 	# Add header breadcrumbs for help in troubleshooting

--- a/src/main/archetype/dispatcher.cloud/src/conf.d/available_vhosts/default.vhost
+++ b/src/main/archetype/dispatcher.cloud/src/conf.d/available_vhosts/default.vhost
@@ -17,6 +17,7 @@ Include conf.d/variables/custom.vars
 	ServerAlias	 "*"
 	# Use a document root that matches the one in conf.dispatcher.d/default.farm
 	DocumentRoot "${DOCROOT}"
+	DispatcherNoCanonURL 1
 	# URI dereferencing algorithm is applied at Sling's level, do not decode parameters here
 	AllowEncodedSlashes NoDecode
 	# Add header breadcrumbs for help in troubleshooting

--- a/src/main/archetype/dispatcher.cloud/src/conf.d/dispatcher_vhost.conf
+++ b/src/main/archetype/dispatcher.cloud/src/conf.d/dispatcher_vhost.conf
@@ -108,6 +108,11 @@ Alias "/system/probes/start" /etc/httpd/probes/startup-status.json
 	Header unset Age
 </IfDefine>
 
+# SITES-3659 Prevent re-encodes of URLs sent to GraphQL Persisted Queries API endpoint
+<LocationMatch "/graphql/execute.json/.*">
+    ProxyPassMatch http://${AEM_HOST}:${AEM_PORT} nocanon
+</LocationMatch>
+
 # (legacy) Allow ingressroute checks through on /systemready (regardless of dispatcher filters)
 <Location "/systemready">
 	ProxyPass http://${AEM_HOST}:${AEM_PORT}/systemready

--- a/src/main/archetype/dispatcher.cloud/src/conf.d/rewrites/default_rewrite.rules
+++ b/src/main/archetype/dispatcher.cloud/src/conf.d/rewrites/default_rewrite.rules
@@ -37,3 +37,7 @@ RewriteRule .* - [F]
 
 # Block wp-login
 RewriteRule ^.*wp-login - [F,NC,L]
+
+# Allow caching of persisted queries
+RewriteCond %{REQUEST_URI} ^/graphql/execute.json
+RewriteRule ^/(.*)$ /$1;.json [PT,L]

--- a/src/main/archetype/dispatcher.cloud/src/conf.dispatcher.d/cache/default_rules.any
+++ b/src/main/archetype/dispatcher.cloud/src/conf.dispatcher.d/cache/default_rules.any
@@ -38,9 +38,3 @@
 	/glob "/screens/channels.json"
 	/type "deny"
 }
-
-# GraphQL cache rules for persistent queries
-/0020 {
-    /glob "/graphql/execute.json/*"
-    /type "deny"
-}


### PR DESCRIPTION
GraphQL persisted queries should be cached by default at dispatcher level. 

## Description

The query parameters sent in the request via dispatcher need to be encoded. One example of such query is
https://publish-p33706-e135212.adobeaemcloud.com/graphql/execute.json/aem-cplotusonlinecommerce-project/getMarketingBannersList%3Btag%3Dmarketing-banner-homepage%3Bpath%3D%2Fcontent%2Fdam%2Faem-cplotusonlinecommerce-project%2Fth%2Fen%2Fhome

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.