### PR TITLE
AEMaaCS image build fails due to Core Forms Components artifacts

### DIFF
--- a/.github/workflows/maven-deploy-cm.yml
+++ b/.github/workflows/maven-deploy-cm.yml
@@ -121,7 +121,7 @@ jobs:
           counter=0
           max=${CM_TEST_RETRIES}
           echo "Looking for ${ARCHETYPE_COMMIT}: ${counter}"
-          until [[ $(curl --silent ${CM_TEST_URL} | grep ${ARCHETYPE_COMMIT}) ]]; do \
+          until [[ $(curl --silent ${CM_TEST_URL}?$(date +%s) | grep ${ARCHETYPE_COMMIT}) ]]; do \
             if [ ${counter} -eq ${max} ]; then \
               echo "Could not find ${ARCHETYPE_COMMIT} after ${counter} tries!"; \
               exit 1; \

--- a/src/main/archetype/all/pom.xml
+++ b/src/main/archetype/all/pom.xml
@@ -194,7 +194,7 @@
                             <target>/apps/${appId}-vendor-packages/application/install</target>
                         </embedded>
 #end
-#if ( $includeExamples == "y" and ( ($includeForms == "y" or $includeFormsenrollment == "y" or $includeFormscommunications == "y" or $includeFormsheadless == "y") and $aemVersion == "cloud" ) )
+#if ( $includeExamples == "y" and ($includeForms == "y" or $includeFormsenrollment == "y" or $includeFormscommunications == "y" or $includeFormsheadless == "y") )
                         <embedded>
                             <groupId>com.adobe.aem</groupId>
                             <artifactId>core-forms-components-examples-apps</artifactId>

--- a/src/main/archetype/all/pom.xml
+++ b/src/main/archetype/all/pom.xml
@@ -197,7 +197,13 @@
 #if ( $includeExamples == "y" and ( ($includeForms == "y" or $includeFormsenrollment == "y" or $includeFormscommunications == "y" or $includeFormsheadless == "y") and $aemVersion == "cloud" ) )
                         <embedded>
                             <groupId>com.adobe.aem</groupId>
-                            <artifactId>core-forms-components-examples-all</artifactId>
+                            <artifactId>core-forms-components-examples-apps</artifactId>
+                            <type>zip</type>
+                            <target>/apps/${appId}-vendor-packages/application/install</target>
+                        </embedded>
+                        <embedded>
+                            <groupId>com.adobe.aem</groupId>
+                            <artifactId>core-forms-components-examples-content</artifactId>
                             <type>zip</type>
                             <target>/apps/${appId}-vendor-packages/application/install</target>
                         </embedded>
@@ -425,7 +431,12 @@
 #if ( $includeExamples == "y" and ( ($includeForms == "y" or $includeFormsenrollment == "y" or $includeFormscommunications == "y" or $includeFormsheadless == "y") and $aemVersion == "cloud" ) )
         <dependency>
             <groupId>com.adobe.aem</groupId>
-            <artifactId>core-forms-components-examples-all</artifactId>
+            <artifactId>core-forms-components-examples-apps</artifactId>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>com.adobe.aem</groupId>
+            <artifactId>core-forms-components-examples-content</artifactId>
             <type>zip</type>
         </dependency>
 #end

--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -895,7 +895,13 @@ Bundle-DocURL:
 #if ( $includeExamples == "y" and ( ($includeForms == "y" or $includeFormsenrollment == "y" or $includeFormscommunications == "y" or $includeFormsheadless == "y") and $aemVersion == "cloud" ) )
             <dependency>
                 <groupId>com.adobe.aem</groupId>
-                <artifactId>core-forms-components-examples-all</artifactId>
+                <artifactId>core-forms-components-examples-apps</artifactId>
+                <type>zip</type>
+                <version>${core.forms.components.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.adobe.aem</groupId>
+                <artifactId>core-forms-components-examples-content</artifactId>
                 <type>zip</type>
                 <version>${core.forms.components.version}</version>
             </dependency>


### PR DESCRIPTION
* Only include examples content as the Forms Core Components are already provided.

Fixes #956
