### PR TITLE
Adobe Datalayer Library getting loaded twice

### DIFF
--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/clientlibs/clientlib-base/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/clientlibs/clientlib-base/.content.xml
@@ -3,4 +3,4 @@
     jcr:primaryType="cq:ClientLibraryFolder"
     allowProxy="{Boolean}true"
     categories="[${appId}.base]"
-    embed="[core.wcm.components.accordion.v1,core.wcm.components.tabs.v1,core.wcm.components.carousel.v1,core.wcm.components.image.v2,core.wcm.components.breadcrumb.v2,core.wcm.components.search.v1,core.wcm.components.form.text.v2,core.wcm.components.pdfviewer.v1,core.wcm.components.commons.datalayer.v1,${appId}.grid]"/>
+    embed="[core.wcm.components.accordion.v1,core.wcm.components.tabs.v1,core.wcm.components.carousel.v1,core.wcm.components.image.v2,core.wcm.components.breadcrumb.v2,core.wcm.components.search.v1,core.wcm.components.form.text.v2,core.wcm.components.pdfviewer.v1,${appId}.grid]"/>


### PR DESCRIPTION
- remove the data layer clientlib from the base clientlibs in apps

Fixes #958 .