### PR TITLE
CIF-2673 - Add navRoot default to landing page template

### DIFF
--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__appId__/settings/wcm/templates/landing-page/initial/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__appId__/settings/wcm/templates/landing-page/initial/.content.xml
@@ -8,7 +8,8 @@
         cq:template="/conf/${appId}/settings/wcm/templates/root-page"
         jcr:primaryType="cq:PageContent" 
         jcr:title="Site root page" 
-        sling:resourceType="${appId}/components/page">
+        sling:resourceType="${appId}/components/page"
+        navRoot="{Boolean}true">
         <root jcr:primaryType="nt:unstructured" 
             sling:resourceType="${appId}/components/container">
             <container jcr:primaryType="nt:unstructured" 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Updated `landing-page` template to set and enable the `navRoot` property by default.

## Related Issue

* https://github.com/adobe/aem-cif-guides-venia/pull/303

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.