### PR TITLE
Enable Web Optimized Images by default on Image component

### DIFF
--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__appId__/settings/wcm/policies/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__appId__/settings/wcm/policies/.content.xml
@@ -73,7 +73,10 @@
 #else
                     allowedRenditionWidths="[320,480,600,800,1024,1200,1600]"
                     disableLazyLoading="false"
-#end
+#end                                        
+#if ( $aemVersion == "cloud" )
+                    enableAssetDelivery="true"
+#end                                                                                
                     allowUpload="false"
                     altValueFromDAM="true"
                     displayPopupTitle="true"


### PR DESCRIPTION
Enable Web Optimized Images by default on Image component via the generated policy, using the policy property 

`enableAssetDelivery=true`

This setting should only be set for AEM as a Cloud Service projects

## Related Issue

N/A

## Motivation and Context

Promotes the use of the high-valuable Web Optimized Images for images in AEM as a Cloud Service.

## How Has This Been Tested?

Using Github projects automated tests w/ this PR.

## Screenshots (if appropriate):

![2022-08-09 at 3 39 PM](https://user-images.githubusercontent.com/1451868/183746847-71e11733-1064-413a-8151-bf404670a81b.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.