### PR TITLE
CQ-4347346 Removing npx dependency from package.json

### DIFF
--- a/src/main/archetype/ui.frontend.react.forms.af/package.json
+++ b/src/main/archetype/ui.frontend.react.forms.af/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\"",
-    "build:dev": "npx webpack --config webpack.dev.js",
-    "build:prod": "npx webpack --config webpack.prod.js && clientlib --verbose",
-    "start": "npx webpack serve --config webpack.dev.js --env mode=development"
+    "build:dev": "webpack --config webpack.dev.js",
+    "build:prod": "webpack --config webpack.prod.js && clientlib --verbose",
+    "start": "webpack serve --config webpack.dev.js --env mode=development"
   },
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
@review @vdua
DOD(Yes)

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The archetype projects makes use of front end maven plugin to build the forms front end module. This plugin does not expose npx in the current execution context. Hence, the build fails if npx is not present globally in the execution context.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.