### PR TITLE
Add note about valid Java package name for groupID

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Name                      | Default        | Description
 `appTitle`                |                | Application title, will be used for website title and components groups (e.g. `"My Site"`).
 `appId`                   |                | Technical name, will be used for component, config and content folder names, as well as client library names (e.g. `"mysite"`).
 `artifactId`              | *`${appId}`*   | Base Maven artifact ID (e.g. `"mysite"`).
-`groupId`                 |                | Base Maven group ID (e.g. `"com.mysite"`).
+`groupId`                 |                | Base Maven group ID (e.g. `"com.mysite"`). This value must be a [valid Java package name.](https://docs.oracle.com/javase/specs/jls/se6/html/packages.html#7.7)
 `package`                 | *`${groupId}`* | Java Source Package (e.g. `"com.mysite"`).
 `version`                 | `1.0-SNAPSHOT` | Project version (e.g. `1.0-SNAPSHOT`).
 `aemVersion`              | `cloud`        | Target AEM version (can be `cloud` for [AEM as a Cloud Service](https://docs.adobe.com/content/help/en/experience-manager-cloud-service/landing/home.html); or `6.5.5` for [Adobe Managed Services](https://github.com/adobe/aem-project-archetype/tree/master/src/main/archetype/dispatcher.ams) or on-premise).


### PR DESCRIPTION
CQDOC-18946

Added note to README.md about valid Java package name for groupID

## Description

See above

## Related Issue

CQDOC-18946

## Motivation and Context

It was a good suggestion from a reader. https://github.com/AdobeDocs/experience-manager-core-components.en/issues/31

## How Has This Been Tested?

Same change passed MD validation in our public docs. See PR#214 on the Core Components repo.

## Screenshots (if appropriate):

None

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change
- [ ] 
## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.