### PR TITLE
CIF-2946: add editor composite status type for cif

### DIFF
--- a/src/main/archetype/ui.config/src/main/content/jcr_root/apps/__appId__/osgiconfig/config.author/com.adobe.granite.resourcestatus.impl.CompositeStatusType~editor.config.cfg.json
+++ b/src/main/archetype/ui.config/src/main/content/jcr_root/apps/__appId__/osgiconfig/config.author/com.adobe.granite.resourcestatus.impl.CompositeStatusType~editor.config.cfg.json
@@ -1,0 +1,8 @@
+{
+    "name": "editor",
+    "types": [
+        "catalog-page",
+        "workflow",
+        "launches"
+    ]
+}

--- a/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -135,6 +135,7 @@ if (includeCommerce == "n") {
     assert new File("$configFolder/config/com.adobe.cq.commerce.core.components.internal.servlets.SpecificPageFilterFactory-default.config").delete()
     assert new File("$configFolder/config.publish/com.adobe.cq.commerce.core.components.internal.services.UrlProviderImpl.cfg.json").delete()
     assert new File("$configFolder/config.publish/com.adobe.cq.commerce.core.components.internal.services.UrlProviderImpl.config").delete()
+    assert new File("$configFolder/config.author/com.adobe.granite.resourcestatus.impl.CompositeStatusType~editor.config.cfg.json").delete()
     assert new File("$appsFolder/components/header").deleteDir()
     assert new File("$confFolder/settings/cloudconfigs/commerce").deleteDir()
     assert new File("$varFolder").deleteDir();
@@ -162,6 +163,7 @@ if (includeCommerce == "n") {
 } else {
     if (aemVersion == "cloud") {
         assert new File("$configFolder/config/com.adobe.cq.commerce.graphql.client.impl.GraphqlClientImpl~default.cfg.json").delete()
+        assert new File("$configFolder/config.author/com.adobe.granite.resourcestatus.impl.CompositeStatusType~editor.config.cfg.json").delete()
         assert new File("$varFolder").deleteDir()
     }
     if (aemVersion.startsWith("6.4")){


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds an overwrite of the editor composite status type for CIF 6.5 projects, adding the catalog-page status provider. 

The configuration is only added with includeCommerce='y' and aemVersion not being cloud.

## Related Issue

CIF-2946
https://github.com/adobe/aem-core-cif-components/pull/849
https://github.com/adobe/aem-cif-guides-venia/pull/308

## Motivation and Context

Show the status when the author edits a CIF template page to warn them about the impact this may have.

## How Has This Been Tested?

manually using `mvn clean install` and inspecting the generated test-cases.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.