### PR TITLE
Security vulnerability: Disable access to /content by default due to vulnerability disclosed separately

### DIFF
--- a/src/main/archetype/dispatcher.ams/src/conf.dispatcher.d/filters/ams_publish_filters.any
+++ b/src/main/archetype/dispatcher.ams/src/conf.dispatcher.d/filters/ams_publish_filters.any
@@ -10,8 +10,7 @@
 # /004 { /type "allow" /url "/apps/*"   }  # allow apps access
 # /005 { /type "allow" /url "/bin/*"    }  # allow bin path access
 
-# This rule allows content to be access
-/0010 { /type "allow" /extension '(css|eot|gif|ico|jpeg|jpg|js|gif|pdf|png|svg|swf|ttf|woff|woff2|html)' /path "/content/*" }  # disable this rule to allow mapped content only
+# This rule allows json models to be accessed
 /0011 { /type "allow" /extension "json" /selectors "model" /path "/content/*" }
 
 # Enable specific mime types clientlibs directories

--- a/src/main/archetype/dispatcher.cloud/src/conf.dispatcher.d/filters/default_filters.any
+++ b/src/main/archetype/dispatcher.cloud/src/conf.dispatcher.d/filters/default_filters.any
@@ -18,8 +18,8 @@
 # /004 { /type "allow" /url "/apps/*"   }  # allow apps access
 # /005 { /type "allow" /url "/bin/*"    }  # allow bin path access
 
-# This rule allows content to be access
-/0010 { /type "allow" /extension '(css|eot|gif|ico|jpeg|jpg|js|gif|pdf|png|svg|swf|ttf|woff|woff2|html|mp4|mov|m4v)' /path "/content/*" }  # disable this rule to allow mapped content only
+# This rule allows json model content to be accessed
+/0010 { /type "allow" /extension "json" /selectors "model" /path "/content/*" }
 
 # Enable specific mime types in non-public content directories
 /0011 { /type "allow" /method "GET" /extension '(css|eot|gif|ico|jpeg|jpg|js|gif|png|svg|swf|ttf|woff|woff2)' }


### PR DESCRIPTION
## Description

Disabled access to /content path for most mime types in dispatcher filters to correct a security vulnerability.
Added default access to /content .json paths in Cloud filters for consistency.

## Related Issue

No open issue since this is a security vulnerability.  Disclosed issue separately to Adobe via Daycare.

## Motivation and Context

Security Vulnerability

## How Has This Been Tested?

Swapped project to use mapped + allowlist specific paths only.

## Screenshots (if appropriate):

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation. (https://experienceleague.adobe.com/docs/experience-manager-dispatcher/using/configuring/dispatcher-configuration.html?lang=en#example-filter-section)
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.