### PR TITLE
bumping aem-cloud-testing-clients to version 1.1.2

### DIFF
--- a/src/main/archetype/it.tests/pom.xml
+++ b/src/main/archetype/it.tests/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>com.adobe.cq</groupId>
             <artifactId>aem-cloud-testing-clients</artifactId>
-            <version>1.0.5</version>
+            <version>1.1.2</version>
         </dependency>
 #elseif ($aemVersion.startsWith("6.5"))
         <dependency>


### PR DESCRIPTION
Upgrade to aem-cloud-testing-clients 1.1.2

## Description

sling-testing-clients were released to get some enhanced logging:
https://issues.apache.org/jira/browse/SLING-11364

Same change was applied to aem-test-samples already
https://github.com/adobe/aem-test-samples/commit/80394ff99dfc7a92e65b0a46251dff04794d24f9

## Related Issue

N/A

## Motivation and Context

Adds enhanced logging for better troubleshooting of customers / Adobe teams upon test failures.

## How Has This Been Tested?

Tested locally by building a new version of the generated test library and running tests against a AEMaaCS test instance

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.