### PR TITLE
Switch to ubuntu-20.04

### DIFF
--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-20.04, macos-latest, windows-latest ]
         java: [8, 11]
 
     steps:


### PR DESCRIPTION
Switch to ubuntu-20.04 as the update to 22.04 (https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/) seems to be causing tests failures:
```
2023-01-10T12:53:01.6940591Z [INFO] [INFO] Compiling @angular/router/testing : es2015 as esm2015
2023-01-10T12:53:05.2477787Z [INFO] [INFO] 10 01 2023 12:53:05.245:INFO [karma-server]: Karma v5.2.3 server started at http://localhost:9876/
2023-01-10T12:53:05.2478369Z [INFO] [INFO] 10 01 2023 12:53:05.247:INFO [launcher]: Launching browsers ChromeHeadless with concurrency unlimited
2023-01-10T12:53:05.2497125Z [INFO] [INFO] (node:2292) [log4js-node-DEP0004] DeprecationWarning: Pattern %d{DATE} is deprecated due to the confusion it causes when used. Please use %d{DATETIME} instead.
2023-01-10T12:53:05.2498554Z [INFO] [INFO] (node:2292) [log4js-node-DEP0004] DeprecationWarning: Pattern %d{DATE} is deprecated due to the confusion it causes when used. Please use %d{DATETIME} instead.
2023-01-10T12:53:05.2505232Z [INFO] [INFO] 10 01 2023 12:53:05.250:INFO [launcher]: Starting browser ChromeHeadless
2023-01-10T12:53:05.2641898Z [INFO] [INFO] (node:2292) [log4js-node-DEP0004] DeprecationWarning: Pattern %d{DATE} is deprecated due to the confusion it causes when used. Please use %d{DATETIME} instead.
2023-01-10T12:53:07.0112167Z [INFO] [INFO] 10 01 2023 12:53:07.010:ERROR [launcher]: Cannot start ChromeHeadless
2023-01-10T12:53:07.0112824Z [INFO] [INFO] 	
2023-01-10T12:53:07.0113978Z [INFO] [INFO] DevTools listening on ws://127.0.0.1:9222/devtools/browser/b96a691d-ec85-4600-a87b-dc10ca506918
2023-01-10T12:53:07.0114595Z [INFO] [INFO] [0110/125305.697634:WARNING:gpu_process_host.cc(1265)] The GPU process has crashed 1 time(s)
2023-01-10T12:53:07.0162860Z [INFO] [INFO] [0110/125305.837689:WARNING:gpu_process_host.cc(1265)] The GPU process has crashed 2 time(s)
2023-01-10T12:53:07.0163597Z [INFO] [INFO] [0110/125305.968590:WARNING:gpu_process_host.cc(1265)] The GPU process has crashed 3 time(s)
2023-01-10T12:53:07.0166297Z [INFO] [INFO] [0110/125306.089230:WARNING:gpu_process_host.cc(1265)] The GPU process has crashed 4 time(s)
2023-01-10T12:53:07.0166760Z [INFO] [INFO] [0110/125306.209451:WARNING:gpu_process_host.cc(1265)] The GPU process has crashed 5 time(s)
2023-01-10T12:53:07.0167158Z [INFO] [INFO] [0110/125306.329345:WARNING:gpu_process_host.cc(1265)] The GPU process has crashed 6 time(s)
2023-01-10T12:53:07.0167866Z [INFO] [INFO] [0110/125306.329371:FATAL:gpu_data_manager_impl_private.cc(407)] GPU process isn't usable. Goodbye.
2023-01-10T12:53:07.0168464Z [INFO] [INFO] #0 0x5565114edb39 base::debug::CollectStackTrace()
```
