### PR TITLE
[AMS Dispatcher] A new flush vhost to invalidate author cache

### DIFF
--- a/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/aem_author_flush.vhost
+++ b/src/main/archetype/dispatcher.ams/src/conf.d/available_vhosts/aem_author_flush.vhost
@@ -1,0 +1,23 @@
+# Collect any enviromental variables that are set in /etc/sysconfig/httpd
+# Collect the dispatchers number
+PassEnv DISP_ID
+# A vhost to flush cache on author dispatcher. Use this vhost in conjunction with adding a Host Header (authorflush) to your AEM flush agent configurations so they fall into this host
+# This is a deliberate flush target that doesn't conflict with customers configurations of the dispatcher
+<VirtualHost *:80>
+	ServerName	"dispauthorflush"
+	ServerAlias	authorflush
+
+	DocumentRoot	${AUTHOR_DOCROOT}
+	# Add header breadcrumbs for help in troubleshooting
+	<IfModule mod_headers.c>
+		Header always add X-Dispatcher ${DISP_ID}
+		Header always add X-Vhost "authorflush"
+	</IfModule>
+	<Directory "${AUTHOR_DOCROOT}">
+		<IfModule disp_apache2.c>
+			SetHandler dispatcher-handler
+		</IfModule>
+		AllowOverride None
+		Require all granted
+	</Directory>
+</VirtualHost>

--- a/src/main/archetype/dispatcher.ams/src/conf.d/enabled_vhosts/aem_author_flush.vhost
+++ b/src/main/archetype/dispatcher.ams/src/conf.d/enabled_vhosts/aem_author_flush.vhost
@@ -1,0 +1,1 @@
+../available_vhosts/aem_author_flush.vhost

--- a/src/main/archetype/dispatcher.ams/src/conf.dispatcher.d/vhosts/ams_author_vhosts.any
+++ b/src/main/archetype/dispatcher.ams/src/conf.dispatcher.d/vhosts/ams_author_vhosts.any
@@ -1,3 +1,4 @@
 # Put hostnames that would be honored for authors blob matching works.
 "author-*"
+"authorflush"
 "${AUTHOR_DEFAULT_HOSTNAME}"


### PR DESCRIPTION

## Description

The PR adds a new vhost  to invalidate cache on author dispatcher in AMS setups. 

## Related Issue

https://github.com/adobe/aem-project-archetype/issues/1037

## Motivation and Context

The current AMS Dispatcher configuration does not provide a way to flush cache on author dispatcher.  Flush requests always resolve to a publisher farm which invalidates content in publisher document root.

The PR adds a new "authorflush" vhost which resolves to the author farm. To use it from AEM you'd need to define a new Flush agent and set `authorflush` in the Host header:

![image](https://user-images.githubusercontent.com/2543854/216817871-3e10da5c-e008-46c9-a9d0-b0f76eef2368.png)

## How Has This Been Tested?
In our setup we use the [Dispatcher Flush UI](https://adobe-consulting-services.github.io/acs-aem-commons/features/dispatcher-flush-ui/index.html) tool, but  the problem is also reproducible from curl.  Execute the commands below while tailing dispatcher.log :

### Current behaviour using the default "flush" vhost. 

```
curl http://localhost/dispatcher/invalidate.cache \
-H "CQ-Action: Delete" \
-H "CQ-Handle: /apps" \
-H "Host: flush"
```

dispatcher resolves publishfarm and invalidates publish docroot (`/mnt/var/www/html`)
```
[Sun Feb 05 13:17:45 2023] [W] [pid 18] No farm matches host 'flush', selected last farm 'publishfarm'
[Sun Feb 05 13:17:45 2023] [D] [pid 18] Found farm publishfarm for flush
[Sun Feb 05 13:17:45 2023] [D] [pid 18] checking [/dispatcher/invalidate.cache]
[Sun Feb 05 13:17:45 2023] [I] [pid 18] Activation detected: action=Delete [/apps]
[Sun Feb 05 13:17:45 2023] [I] [pid 18] Touched /mnt/var/www/html/.stat
[Sun Feb 05 13:17:45 2023] [D] [pid 18] response.status = 200
```
### The fixed behaviour  using the new "authorflush" vhost. 

```
curl http://localhost/dispatcher/invalidate.cache \
-H "CQ-Action: Delete" \
-H "CQ-Handle: /apps" \
-H "Host: authorflush"
```

dispatcher resolves authorfarm and invalidates publish docroot (`/mnt/var/www/author`)
```
[Sun Feb 05 13:32:26 2023] [D] [pid 26] Found farm authorfarm for authorflush
[Sun Feb 05 13:32:26 2023] [D] [pid 26] checking [/dispatcher/invalidate.cache]
[Sun Feb 05 13:32:26 2023] [I] [pid 26] Activation detected: action=Delete [/apps]
[Sun Feb 05 13:32:26 2023] [I] [pid 26] Touched /mnt/var/www/author/.stat
[Sun Feb 05 13:32:26 2023] [D] [pid 26] response.status = 200
```


## Screenshots (if appropriate):

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.


