### PR TITLE
Adding the ability to put cs mainteance tasks in the build

### DIFF
--- a/src/main/archetype/ui.apps/src/main/content/META-INF/vault/filter.xml
+++ b/src/main/archetype/ui.apps/src/main/content/META-INF/vault/filter.xml
@@ -9,4 +9,7 @@
 #if ( $singleCountry  == "n" )
     <filter root="/apps/msm/${appId}_blueprint" mode="merge"/>
 #end
+#if ($aemVersion == "cloud")
+    <filter root="/apps/settings" mode="merge" />
+#end
 </workspaceFilter>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/settings/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/settings/.content.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:rep="internal" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    jcr:mixinTypes="[rep:AccessControllable]"
+    jcr:primaryType="sling:Folder"/>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/settings/granite/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/settings/granite/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    jcr:primaryType="sling:Folder"/>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/settings/granite/operations/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/settings/granite/operations/.content.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    jcr:primaryType="sling:OrderedFolder">
+    <hc/>
+    <maintenance/>
+    <monitoring/>
+</jcr:root>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/settings/granite/operations/maintenance/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/settings/granite/operations/maintenance/.content.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    jcr:primaryType="sling:OrderedFolder"
+    sling:configCollectionInherit="true"
+    sling:configPropertyInherit="true">
+    <granite_daily/>
+    <granite_weekly/>
+</jcr:root>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/settings/granite/operations/maintenance/granite_daily/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/settings/granite/operations/maintenance/granite_daily/.content.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    jcr:primaryType="sling:OrderedFolder"
+    sling:configCollectionInherit="true"
+    sling:configPropertyInherit="true"
+    sling:resourceType="granite/operations/components/maintenance/window"
+    name="Daily Maintenance Window"
+    windowEndTime="5:00"
+    windowSchedule="daily"
+    windowStartTime="2:00">
+    <granite_WorkflowPurgeTask/>
+</jcr:root>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/settings/granite/operations/maintenance/granite_daily/granite_WorkflowPurgeTask/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/settings/granite/operations/maintenance/granite_daily/granite_WorkflowPurgeTask/.content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    jcr:primaryType="nt:unstructured"
+    sling:resourceType="granite/operations/components/maintenance/task"
+    granite.maintenance.name="WorkflowPurgeTask"
+    granite.task.hint="HINT: Please add workflow models to be deleted to the workflow-purge configuration, which is available under Adobe Granite Workflow Purge Configuration under Web Console Configuration-Manager."/>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/settings/granite/operations/maintenance/granite_weekly/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/settings/granite/operations/maintenance/granite_weekly/.content.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    jcr:primaryType="sling:OrderedFolder"
+    sling:configCollectionInherit="true"
+    sling:configPropertyInherit="true"
+    sling:resourceType="granite/operations/components/maintenance/window"
+    name="Weekly Maintenance Window"
+    windowEndTime="2:00"
+    windowSchedule="weekly"
+    windowScheduleWeekdays="{Long}7"
+    windowStartTime="1:00">
+    <granite_ProjectPurgeTask/>
+    <granite_TaskPurgeTask/>
+</jcr:root>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/settings/granite/operations/maintenance/granite_weekly/granite_ProjectPurgeTask/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/settings/granite/operations/maintenance/granite_weekly/granite_ProjectPurgeTask/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    jcr:primaryType="nt:unstructured"
+    sling:resourceType="granite/operations/components/maintenance/task"
+    granite.maintenance.name="ProjectPurgeTask"/>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/settings/granite/operations/maintenance/granite_weekly/granite_TaskPurgeTask/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/settings/granite/operations/maintenance/granite_weekly/granite_TaskPurgeTask/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    jcr:primaryType="nt:unstructured"
+    sling:resourceType="granite/operations/components/maintenance/task"
+    granite.maintenance.name="TaskPurge"/>

--- a/src/main/archetype/ui.config/src/main/content/jcr_root/apps/__appId__/osgiconfig/config/com.adobe.cq.projects.purge.Scheduler~default.cfg.json
+++ b/src/main/archetype/ui.config/src/main/content/jcr_root/apps/__appId__/osgiconfig/config/com.adobe.cq.projects.purge.Scheduler~default.cfg.json
@@ -1,0 +1,5 @@
+{
+    "scheduledpurge.purgeGroups":true,
+    "scheduledpurge.terminateRunningWorkflows":true,
+    "scheduledpurge.name":"Purge projects over 60 days old"
+}

--- a/src/main/archetype/ui.config/src/main/content/jcr_root/apps/__appId__/osgiconfig/config/com.adobe.granite.taskmanagement.impl.purge.TaskPurgeMaintenanceTask.cfg.json
+++ b/src/main/archetype/ui.config/src/main/content/jcr_root/apps/__appId__/osgiconfig/config/com.adobe.granite.taskmanagement.impl.purge.TaskPurgeMaintenanceTask.cfg.json
@@ -1,0 +1,3 @@
+{
+    "purgeCompleted":true
+}

--- a/src/main/archetype/ui.config/src/main/content/jcr_root/apps/__appId__/osgiconfig/config/com.adobe.granite.workflow.purge.Scheduler~default.cfg.json
+++ b/src/main/archetype/ui.config/src/main/content/jcr_root/apps/__appId__/osgiconfig/config/com.adobe.granite.workflow.purge.Scheduler~default.cfg.json
@@ -1,0 +1,3 @@
+{
+    "scheduledpurge.name":"Purge All Completed Workflows over 30 days old"
+}

--- a/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -72,6 +72,13 @@ if (amp == "n"){
     assert new File(uiAppsPackage, "src/main/content/jcr_root/apps/" + appId + "/components/tabs/clientlibs").deleteDir()
 }
 
+if (aemVersion != "cloud") {
+    assert new File("$uiAppsPackage/src/main/content/jcr_root/apps/settings").deleteDir()
+    assert new File("$configFolder/config/com.adobe.cq.projects.purge.Scheduler~default.cfg.json").delete()
+    assert new File("$configFolder/config/com.adobe.granite.workflow.purge.Scheduler~default.cfg.json").delete()
+    assert new File("$configFolder/config/com.adobe.granite.taskmanagement.impl.purge.TaskPurgeMaintenanceTask.cfg.json").delete()
+}
+
 if (includeErrorHandler == "n") {
     assert new File(uiAppsPackage, "src/main/content/jcr_root/apps/sling").deleteDir()
 }


### PR DESCRIPTION
Adding the ability to include maintenance tasks for AEMaaCS instances

## Description

Some customers are starting to suffer from not running maintenance tasks on AEMaaCS and for that reason I would like to make that part of the archetype.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Some clients have been on AEMaaCS for over a few years now and not purging workflows/projects is starting to cause delays in loading pages. Since enabling maintenance tasks requires a code change in AEMaaCS I would like to include this configuration as part of the archetype.

## How Has This Been Tested?

1. mvn clean install
2. Manually generated the archetype after building it and installing it in a AEM instance

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.