### PR TITLE
SITES-13330 = Component Resize is not working in Layout for tablet-horizontal

### DIFF
--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/clientlibs/clientlib-grid/less/grid.less
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appId__/clientlibs/clientlib-grid/less/grid.less
@@ -25,14 +25,14 @@
 }
 
 /* phone breakpoint */
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .aem-Grid {
     .generate-grid(phone, @max_col);
   }
 }
 
 /* tablet breakpoint */
-@media (min-width: 769px) and (max-width: 1200px) {
+@media (min-width: 768px) and (max-width: 1200px) {
   .aem-Grid {
     .generate-grid(tablet, @max_col);
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Update breakpoint to match editor tablet emulator width

## Description

<!--- Describe your changes in detail -->
Emulator width for tablet in editor is 768px. Since this is the phone breakpoint in the css, tablet breakpoint gets set to 769px and hence the appropriate styles for tablet are not getting applied in the emulator.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Layout updates can be done in tablet emulator mode in AEM CS page editor.


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.