### PR TITLE
Enable UI testing by default

### DIFF
--- a/src/main/archetype/ui.tests/assembly-ui-test-docker-context.xml
+++ b/src/main/archetype/ui.tests/assembly-ui-test-docker-context.xml
@@ -31,6 +31,7 @@
             <includes>
                 <include>Dockerfile</include>
                 <include>wait-for-grid.sh</include>
+                <include>testing.properties</include>
             </includes>
         </fileSet>
         <fileSet>

--- a/src/main/archetype/ui.tests/testing.properties
+++ b/src/main/archetype/ui.tests/testing.properties
@@ -1,0 +1,1 @@
+ui-tests.version=1


### PR DESCRIPTION
Enable UI testing by default in the archetype used when generating a new project.

## Description
When a new repository is created inside Adobe CloudManager, it is populated with some default application code. The code also contains sample tests but the UI testing was disabled by default. This change will enable it for newly created repositories.

Issue: CMGR-45308

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:


- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.