### PR TITLE
Add slf4jtest.properties to print out WARN and ERROR message during unit test execution

### DIFF
--- a/src/main/archetype/core/src/test/resources/slf4jtest.properties
+++ b/src/main/archetype/core/src/test/resources/slf4jtest.properties
@@ -1,0 +1,1 @@
+print.level=WARN

--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -234,6 +234,12 @@
                         <include>**/*.java</include>
                     </includes>
                 </fileSet>
+                <fileSet filtered="true" encoding="UTF-8">
+                    <directory>src/test/resources</directory>
+                    <includes>
+                        <include>**/*.properties</include>
+                    </includes>
+                </fileSet>
             </fileSets>
         </module>
         <module id="${rootArtifactId}.dispatcher.ams" dir="dispatcher.ams" name="dispatcher.ams">


### PR DESCRIPTION
By default, no log messages are printed to console while running the unit tests (default configuration of the used `uk.org.lidalia:slf4j-test` library).

Especially when using Sling Models in unit tests, the root cause of errors are often only logged, whereas the executing code itself gets a different error (e.g. adapting to a model returns null). So it is recommended to enable WARN and ERROR log level when running your unit tests.