### PR TITLE
AppAemContext: Pass through resourceResolverType parameter to AemContextBuilder

### DIFF
--- a/src/main/archetype/core/src/test/java/core/testcontext/AppAemContext.java
+++ b/src/main/archetype/core/src/test/java/core/testcontext/AppAemContext.java
@@ -48,10 +48,11 @@ public final class AppAemContext {
     }
 
     /**
+     * @param resourceResolverType Resource resolver type
      * @return {@link AemContextBuilder}
      */
     public static AemContextBuilder newAemContextBuilder(ResourceResolverType resourceResolverType) {
-        return new AemContextBuilder()
+        return new AemContextBuilder(resourceResolverType)
                 .plugin(CACONFIG)
                 .plugin(CORE_COMPONENTS)
                 .afterSetUp(SETUP_CALLBACK);


### PR DESCRIPTION
This fixes a small bug introduced in #848 - the newly introduced parameter `resourceResolverType` was never actually used.