### PR TITLE
Update pom.xml to match Adobe Recommendation

### DIFF
--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -330,7 +330,7 @@ Bundle-DocURL:
                     <groupId>org.apache.jackrabbit</groupId>
                     <artifactId>filevault-package-maven-plugin</artifactId>
                     <extensions>true</extensions>
-                    <version>1.1.6</version>
+                    <version>1.3.2</version>
                     <configuration>
                         <filterSource>src/main/content/META-INF/vault/filter.xml</filterSource>
                         <validatorsSettings>

--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -330,7 +330,7 @@ Bundle-DocURL:
                     <groupId>org.apache.jackrabbit</groupId>
                     <artifactId>filevault-package-maven-plugin</artifactId>
                     <extensions>true</extensions>
-                    <version>1.3.2</version>
+                    <version>1.3.4</version>
                     <configuration>
                         <filterSource>src/main/content/META-INF/vault/filter.xml</filterSource>
                         <validatorsSettings>


### PR DESCRIPTION
According to the docs for custom indexing adobe highly recommends to use a version of jackrabbit >= 1.3.2

The provided version in the archtype is older and leads to issues when deploying to cloud with a custom index in place. Updating the version resolves potential issues upfront.

Source: https://experienceleague.adobe.com/docs/experience-manager-cloud-service/content/operations/indexing.html?lang=en#project-configuration

## Motivation and Context

Archetype should always be inline with adobe docs

## How Has This Been Tested?

build and deploy on sandbox envs.


## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.