### PR TITLE
Updating archetype dispatcher.cloud configuration to version 2.0.191

### DIFF
--- a/src/main/archetype/dispatcher.cloud/src/conf.d/dispatcher_vhost.conf
+++ b/src/main/archetype/dispatcher.cloud/src/conf.d/dispatcher_vhost.conf
@@ -60,7 +60,12 @@ Alias "/system/probes/start" probes/startup-status.json
 	DispatcherConfig conf.dispatcher.d/dispatcher.any
 
 	# Format for the dispatcher log file
-	LogFormat "%t \"%m %{dispatcher:uri}e%q %H\" %{dispatcher:status}e %{dispatcher:cache}e [%{dispatcher:backend}e] %{ms}Tms \"%{Host}i\"" dispatcher
+	<IfDefine !LOG_X_REQUEST_ID>
+		LogFormat "%t \"%m %{dispatcher:uri}e%q %H\" %{dispatcher:status}e %{dispatcher:cache}e [%{dispatcher:backend}e] %{ms}Tms \"%{Host}i\"" dispatcher
+	</IfDefine>
+	<IfDefine LOG_X_REQUEST_ID>
+		LogFormat "%t \"%m %{dispatcher:uri}e%q %H\" %{dispatcher:status}e %{dispatcher:cache}e [%{dispatcher:backend}e] %{ms}Tms \"%{Host}i\" \"%{x-request-id}i\"" dispatcher
+	</IfDefine>
 	CustomLog "| /usr/sbin/rotatelogs -e -f -t logs/dispatcher.log 86400" dispatcher "expr=%{HANDLER} == 'dispatcher-handler'"
 
 	# Log level for the dispatcher module

--- a/src/main/archetype/dispatcher.cloud/src/conf.dispatcher.d/filters/default_filters.any
+++ b/src/main/archetype/dispatcher.cloud/src/conf.dispatcher.d/filters/default_filters.any
@@ -98,3 +98,6 @@
 
 # Allow Forms Document Services requests
 /0062 { /type "allow" /method '(GET|POST)' /url "/adobe/forms/*" }
+
+# Allow PUT for Forms DocAssurance Services Decryption API
+/0063 { /type "allow" /method "PUT" /url "/adobe/forms/document/assure/encrypt" }


### PR DESCRIPTION
sync dispatcher immutable files with Dispatcher SDK and image v2.0.191

## Description

Since the previous sync of dispatcher immutable files with Dispatcher SDK and image was from version 2.0.166 in February 2023 and AEM CS releases already progressed further, including dispatcher image and SDK tooling containing newer files, it resulted already in customer using latest public AEM CS releases being out of sync and reporting issues like https://github.com/adobe/aem-project-archetype/issues/1043

Hence we propose to sync those files with the ones from the latest Dispatcher SDK and image v2.0.191 in order for validation scripts not to fail in immutable files compatibility check step as described in https://experienceleague.adobe.com/docs/experience-manager-cloud-service/content/implementing/content-delivery/validation-debug.html?lang=en#third-phase

## Related Issue

https://github.com/adobe/aem-project-archetype/issues/1043

## Motivation and Context

Not to fail immutable files validation step described in https://experienceleague.adobe.com/docs/experience-manager-cloud-service/content/implementing/content-delivery/validation-debug.html?lang=en#third-phase when using Dispatcher SDK tooling from the latest AEM CS releases.

## How Has This Been Tested?

```
$ bin/validate.sh /Users/krystian/devel/adobe/skyline/skyline-dispatcher-sdk/aem-project-archetype/src/main/archetype/dispatcher.cloud/src
opt-in USE_SOURCES_DIRECTLY marker file detected
Phase 1: Dispatcher validator
Cloud manager validator 2.0.62
2023/10/04 13:40:11 No issues found
Phase 1 finished successfully
Phase 2: httpd -t validation in docker image
(...)
VirtualHost configuration:
*:80                   is a NameVirtualHost
         default server publish (/etc/httpd/conf.d/enabled_vhosts/default.vhost:14)
         port 80 namevhost publish (/etc/httpd/conf.d/enabled_vhosts/default.vhost:14)
                 wild alias *
         port 80 namevhost unmatched-host-catch-all (/etc/httpd/conf.d/dispatcher_vhost.conf:284)
                 wild alias *
Phase 2 finished successfully
Phase 3: Immutability check
empty mode param, assuming mode = 'check'
running in 'check' mode
running in 'check' mode
reading immutable file list from /etc/httpd/immutable.files.txt
checking 'conf.d/available_vhosts/default.vhost' immutability (if present)
checking existing 'conf.d/available_vhosts/default.vhost' for changes
checking 'conf.d/dispatcher_vhost.conf' immutability (if present)
replacing include directive in 'conf.d/dispatcher_vhost.conf' before proceeding
checking existing 'conf.d/dispatcher_vhost.conf' for changes
checking 'conf.d/enabled_vhosts/vhosts.conf' immutability (if present)
checking existing 'conf.d/enabled_vhosts/vhosts.conf' for changes
checking 'conf.d/rewrites/default_rewrite.rules' immutability (if present)
checking existing 'conf.d/rewrites/default_rewrite.rules' for changes
checking 'conf.dispatcher.d/available_farms/default.farm' immutability (if present)
checking existing 'conf.dispatcher.d/available_farms/default.farm' for changes
checking 'conf.dispatcher.d/cache/default_invalidate.any' immutability (if present)
replacing 'conf.dispatcher.d/cache/default_invalidate.any' content as it gets overridden on startup anyway
checking existing 'conf.dispatcher.d/cache/default_invalidate.any' for changes
checking 'conf.dispatcher.d/cache/default_rules.any' immutability (if present)
checking existing 'conf.dispatcher.d/cache/default_rules.any' for changes
checking 'conf.dispatcher.d/clientheaders/default_clientheaders.any' immutability (if present)
checking existing 'conf.dispatcher.d/clientheaders/default_clientheaders.any' for changes
checking 'conf.dispatcher.d/dispatcher.any' immutability (if present)
replacing include directive in 'conf.dispatcher.d/dispatcher.any' before proceeding
checking existing 'conf.dispatcher.d/dispatcher.any' for changes
checking 'conf.dispatcher.d/enabled_farms/farms.any' immutability (if present)
checking existing 'conf.dispatcher.d/enabled_farms/farms.any' for changes
checking 'conf.dispatcher.d/filters/default_filters.any' immutability (if present)
checking existing 'conf.dispatcher.d/filters/default_filters.any' for changes
checking 'conf.dispatcher.d/renders/default_renders.any' immutability (if present)
checking existing 'conf.dispatcher.d/renders/default_renders.any' for changes
checking 'conf.dispatcher.d/virtualhosts/default_virtualhosts.any' immutability (if present)
checking existing 'conf.dispatcher.d/virtualhosts/default_virtualhosts.any' for changes
no immutable file has been changed - check is SUCCESSFUL
Phase 3 finished successfully
```

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.