### PR TITLE
Bump AEM Cloud Testing Clients to version 1.2.1

### DIFF
--- a/src/main/archetype/it.tests/pom.xml
+++ b/src/main/archetype/it.tests/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>com.adobe.cq</groupId>
             <artifactId>aem-cloud-testing-clients</artifactId>
-            <version>1.1.2</version>
+            <version>1.2.1</version>
         </dependency>
 #elseif ($aemVersion.startsWith("6.5"))
         <dependency>


### PR DESCRIPTION
Bump AEM Cloud Testing Clients to version 1.2.1

New testing clients will be needed in the future because of SLING-12086

