### PR TITLE
Ensuring the client attempts to resolve valid URLs only

### DIFF
--- a/src/main/archetype/it.tests/src/main/java/it/tests/HtmlUnitClient.java
+++ b/src/main/archetype/it.tests/src/main/java/it/tests/HtmlUnitClient.java
@@ -149,11 +149,13 @@ public class HtmlUnitClient extends CQClient {
                 String[] widths = width.split(",");
                 for (String w: widths) {
                     String ref = src.replace("{.width}", "."+w);
+                    String ref = src.replace("{width}", w); // accounting for templated asset-delivery src urls
                     result.add(baseUri.resolve(ref));
                 }
             } else if (src != null && width == null) {
                 // happens with SVG and GIFs
                 String ref = src.replace("{.width}", "");
+                String ref = src.replace("&width={width}", ""); // accounting for templated asset-delivery src urls
                 result.add(baseUri.resolve(ref));
             }
         }


### PR DESCRIPTION
With updates in the Image Core Component to support template strings for asset-delivery URLs [0], the test code must also account for it in line with that the clientlibrary does [1] to prevent errors like [2] in testing Image Core Component generated URLs when asset-delivery is enabled.

[0] https://github.com/adobe/aem-core-wcm-components/blob/18694ef650f936970720ffc370db7497a20ac7d9/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ImageImpl.java#L234-L236 [1] https://github.com/adobe/aem-core-wcm-components/blob/18694ef650f936970720ffc370db7497a20ac7d9/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js#L201 [2]
```
[ERROR] com.example.it.tests.PublishPageValidationIT.validateHomepage  Time elapsed: 6.794 s  <<< ERROR!
java.lang.IllegalArgumentException: Illegal character in query at index 113: /adobe/dynamicmedia/deliver/dm-aid--2dc846e3-59e9-48d9-92c0-397d20c735e3/hp-hero-video.png?preferwebp=true&width={width}&quality=85
	at java.base/java.net.URI.create(URI.java:883)
	at java.base/java.net.URI.resolve(URI.java:1066)
	at com.example.it.tests.HtmlUnitClient.getCoreComponentImageRenditions(HtmlUnitClient.java:152)
	at com.example.it.tests.HtmlUnitClient.getResourceRefs(HtmlUnitClient.java:65)
	at com.example.it.tests.PublishPageValidationIT.verifyLinkedResources(PublishPageValidationIT.java:97)
	at com.example.it.tests.PublishPageValidationIT.validateHomepage(PublishPageValidationIT.java:81)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
	at org.apache.sling.testing.junit.rules.TestStickyCookieRule$1.evaluate(TestStickyCookieRule.java:34)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.apache.sling.testing.junit.rules.instance.ExistingInstanceStatement.evaluate(ExistingInstanceStatement.java:62)
	at org.apache.sling.testing.junit.rules.instance.ExistingInstanceStatement.evaluate(ExistingInstanceStatement.java:62)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
	at org.junit.vintage.engine.execution.RunnerExecutor.execute(RunnerExecutor.java:42)
	at org.junit.vintage.engine.VintageTestEngine.executeAllChildren(VintageTestEngine.java:80)
	at org.junit.vintage.engine.VintageTestEngine.execute(VintageTestEngine.java:72)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:220)
	at org.junit.platform.launcher.core.DefaultLauncher.lambda$execute$6(DefaultLauncher.java:188)
	at org.junit.platform.launcher.core.DefaultLauncher.withInterceptedStreams(DefaultLauncher.java:202)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:181)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:128)
	at org.apache.maven.surefire.junitplatform.LazyLauncher.execute(LazyLauncher.java:55)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:223)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:175)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:135)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:456)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:169)
	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:595)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:581)
Caused by: java.net.URISyntaxException: Illegal character in query at index 113: /adobe/dynamicmedia/deliver/dm-aid--2dc846e3-59e9-48d9-92c0-397d20c735e3/hp-hero-video.png?preferwebp=true&width={width}&quality=85
	at java.base/java.net.URI$Parser.fail(URI.java:2913)
	at java.base/java.net.URI$Parser.checkChars(URI.java:3084)
	at java.base/java.net.URI$Parser.parseHierarchical(URI.java:3172)
	at java.base/java.net.URI$Parser.parse(URI.java:3125)
	at java.base/java.net.URI.<init>(URI.java:600)
	at java.base/java.net.URI.create(URI.java:881)
	... 56 more
```

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.