### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/maven-deploy-cm.yml
+++ b/.github/workflows/maven-deploy-cm.yml
@@ -61,7 +61,7 @@ jobs:
         id: getCommit
         run: |
           echo "Commit: ${ARCHETYPE_COMMIT}"
-          echo ::set-output name=commit::${ARCHETYPE_COMMIT}
+          echo "commit=${ARCHETYPE_COMMIT}" >> $GITHUB_OUTPUT
       # Create new project
       - name: Create new project with the archetype
         run: |

--- a/.github/workflows/maven-sdk-update.yml
+++ b/.github/workflows/maven-sdk-update.yml
@@ -63,7 +63,7 @@ jobs:
         id: getCommit
         run: |
           echo "Commit: ${ARCHETYPE_COMMIT}"
-          echo ::set-output name=commit::${ARCHETYPE_COMMIT}
+          echo "commit=${ARCHETYPE_COMMIT}" >> $GITHUB_OUTPUT
       # Create new project
       - name: Create new project with the archetype
         run: |


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter