### PR TITLE
ASSETS-35923 create .cloudmanager/java-version for cloud projects, min jdk11

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
 
       # Set up dependency cache
       - name: Cache local Maven repository
@@ -49,7 +49,7 @@ jobs:
         run: |
           echo $GPG_SECRET_KEYS | base64 --decode | gpg --import --no-tty --batch --yes
           echo $GPG_OWNERTRUST | base64 --decode | gpg --import-ownertrust --no-tty --batch --yes
-          
+
       - name: Configure git user for release commits
         env:
           X_GITHUB_USERNAME: ${{ secrets.ADOBE_BOT_GITHUB_USERNAME  }}

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 8
 
       # Set up dependency cache
       - name: Cache local Maven repository
@@ -49,7 +49,7 @@ jobs:
         run: |
           echo $GPG_SECRET_KEYS | base64 --decode | gpg --import --no-tty --batch --yes
           echo $GPG_OWNERTRUST | base64 --decode | gpg --import-ownertrust --no-tty --batch --yes
-
+          
       - name: Configure git user for release commits
         env:
           X_GITHUB_USERNAME: ${{ secrets.ADOBE_BOT_GITHUB_USERNAME  }}

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,16 @@
         </profile>
 
         <profile>
+            <id>it-java8</id>
+            <activation>
+                <jdk>[1.8,11)</jdk>
+            </activation>
+            <properties>
+                <archetype.test.projectsDirectory>${project.build.testOutputDirectory}/projects-1_8</archetype.test.projectsDirectory>
+            </properties>
+        </profile>
+
+        <profile>
             <!-- This is the release profile. -->
             <id>release</id>
             <activation>

--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -169,8 +169,12 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+#if ( $aemVersion == "cloud")
+                    <release>11</release>
+#else
                     <source>1.8</source>
                     <target>1.8</target>
+#end
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -148,10 +148,17 @@
                                 <requireMavenVersion>
                                     <version>[3.3.9,)</version>
                                 </requireMavenVersion>
+#if ( $aemVersion == "cloud")
+                                <requireJavaVersion>
+                                    <message>Maven must be executed with a Java 11 JRE or higher.</message>
+                                    <version>11</version>
+                                </requireJavaVersion>
+#else
                                 <requireJavaVersion>
                                     <message>Maven must be executed with a Java 8 JRE or higher.</message>
                                     <version>1.8.0</version>
                                 </requireJavaVersion>
+#end
                             </rules>
                         </configuration>
                     </execution>

--- a/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -88,6 +88,9 @@ if (aemVersion == "cloud") {
     }
     println "Using AEM as a Cloud Service SDK version: " + sdkVersion
     rootPom.text = rootPom.text.replaceAll('SDK_VERSION', sdkVersion.toString())
+    def cloudManagerDir = new File(rootDir, ".cloudmanager");
+    assert cloudManagerDir.mkdir();
+    new File(cloudManagerDir, "java-version").write("11");
 }
 
 buildContentSkeleton(uiContentPackage, uiAppsPackage, singleCountry, appId, language, country)
@@ -259,7 +262,7 @@ if (includeForms == "y" || includeFormsenrollment == "y" || includeFormscommunic
     }
     println "Using AEM Forms as a Cloud Service SDK version: " + sdkFormsVersion
     rootPom.text = rootPom.text.replaceAll('SDK_FORMS_VERSION', sdkFormsVersion.toString())
-    
+
 }
 
 // if config.publish folder ends up empty, remove it, otherwise the filevault-package-maven-plugin will throw

--- a/src/test/resources/projects-1_8/basic
+++ b/src/test/resources/projects-1_8/basic
@@ -1,0 +1,1 @@
+../projects/basic

--- a/src/test/resources/projects-1_8/basic-6.5.0
+++ b/src/test/resources/projects-1_8/basic-6.5.0
@@ -1,0 +1,1 @@
+../projects/basic-6.5.0

--- a/src/test/resources/projects-1_8/cif
+++ b/src/test/resources/projects-1_8/cif
@@ -1,0 +1,1 @@
+../projects/cif

--- a/src/test/resources/projects-1_8/forms-basic-6.5.0
+++ b/src/test/resources/projects-1_8/forms-basic-6.5.0
@@ -1,0 +1,1 @@
+../projects/forms-basic-6.5.0

--- a/src/test/resources/projects-1_8/frontend-angular
+++ b/src/test/resources/projects-1_8/frontend-angular
@@ -1,0 +1,1 @@
+../projects/frontend-angular

--- a/src/test/resources/projects-1_8/frontend-angular-ssr
+++ b/src/test/resources/projects-1_8/frontend-angular-ssr
@@ -1,0 +1,1 @@
+../projects/frontend-angular-ssr

--- a/src/test/resources/projects-1_8/frontend-general
+++ b/src/test/resources/projects-1_8/frontend-general
@@ -1,0 +1,1 @@
+../projects/frontend-general

--- a/src/test/resources/projects-1_8/frontend-react
+++ b/src/test/resources/projects-1_8/frontend-react
@@ -1,0 +1,1 @@
+../projects/frontend-react

--- a/src/test/resources/projects-1_8/frontend-react-ssr
+++ b/src/test/resources/projects-1_8/frontend-react-ssr
@@ -1,0 +1,1 @@
+../projects/frontend-react-ssr


### PR DESCRIPTION
Projects created for cloud should be expected to build with a minimum jdk version of 11.

## Description

* create `.cloudmanager/java-version` for cloud projects with text content `11`, per [Setting the Maven JDK Version
](https://experienceleague.adobe.com/docs/experience-manager-cloud-service/content/implementing/using-cloud-manager/create-application-project/build-environment-details.html?lang=en#alternate-maven-jdk-version)
* change the maven-enforcer-plugin rule for java-version to require version 11 instead of 1.8 
* create a `it-java8` profile that changes the `archetype.test.projectsDirectory` when executed with jdk 1.8 to point to a new sibling folder `projects-1_8` containing symbolic links to non-cloud IT project directories, so that the archetype project itself continues to build successfully for both jdk1.8 and jdk11 executions.

## Related Issue

ASSETS-35923 Release 15262 aem-sdk-api breaks the sample unit tests in aem-project-archetype projects when running under JDK8, including new sandbox programs

## Motivation and Context

Upstream project dependencies of AEM are gradually moving to Java 11+ targets, which are compatible with the AEM Cloud Service runtime, but not compatible with the default Cloud Manager JDK version 1.8. Until the minimum supported version of AEM on AMS/On-Prem is raised above 1.8, the archetype should extend its conditional logic for cloud vs non-cloud to govern the required JDK version as well, so that cloud projects and the cloud SDK can evolve more cohesively.

## How Has This Been Tested?

Executed the archetype locally under jdk 1.8 and jdk 11 to confirm that the tests pass and that the aemVersion=cloud IT projects contain a `.cloudmanager/java-version` file with the contents `11` and that they fail early if they are built with jdk 1.8.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.