### PR TITLE
Update README.md to reference latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To generate a project, adjust the following command line to your needs:
 mvn -B org.apache.maven.plugins:maven-archetype-plugin:3.3.1:generate \
  -D archetypeGroupId=com.adobe.aem \
  -D archetypeArtifactId=aem-project-archetype \
- -D archetypeVersion=52\
+ -D archetypeVersion=53\
  -D appTitle="My Site" \
  -D appId="mysite" \
  -D groupId="com.mysite"
@@ -101,7 +101,7 @@ mvn -B org.apache.maven.plugins:maven-archetype-plugin:3.3.1:generate \
 
 | Archetype                                                                                  | AEM as a Cloud Service | AEM 6.5   | Java SE | Maven  |
 |--------------------------------------------------------------------------------------------|------------------------|-----------|---------|--------|
-| [52](https://github.com/adobe/aem-project-archetype/releases/tag/aem-project-archetype-52) | Continual              | 6.5.17.0+ | 11      | 3.3.9+ |
+| [53](https://github.com/adobe/aem-project-archetype/releases/tag/aem-project-archetype-53) | Continual              | 6.5.17.0+ | 11      | 3.3.9+ |
 
 Setup your local development environment for [AEM as a Cloud Service SDK](https://experienceleague.adobe.com/docs/experience-manager-learn/cloud-service/local-development-environment-set-up/overview.html) or for [older versions of AEM.](https://experienceleague.adobe.com/docs/experience-manager-learn/foundation/development/set-up-a-local-aem-development-environment.html)
 


### PR DESCRIPTION

## Description
With the release of 53 the readme was update to use archetype-plugin:3.3.1

this change only works if the archetype-post-generate.groovy script also references `groovy.xml.XmlSlurper` instead of `groovy.util.XmlSlurper`

## Related Issue
https://github.com/adobe/aem-project-archetype/issues/1274
https://github.com/adobe/aem-project-archetype/issues/1276


## Motivation and Context

making it work 
## How Has This Been Tested?

locally executing with proper version of archetype

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:


- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.