### PR TITLE
Use explicit configuration: <outputDirectory>/</outputDirectory>

### DIFF
--- a/src/main/archetype/dispatcher.ams/assembly.xml
+++ b/src/main/archetype/dispatcher.ams/assembly.xml
@@ -12,7 +12,7 @@
             <includes>
                 <include>**/*</include>
             </includes>
-            <outputDirectory></outputDirectory>
+            <outputDirectory>/</outputDirectory>
         </fileSet>
     </fileSets>
 </assembly>

--- a/src/main/archetype/dispatcher.cloud/assembly.xml
+++ b/src/main/archetype/dispatcher.cloud/assembly.xml
@@ -12,7 +12,7 @@
             <includes>
                 <include>**/*</include>
             </includes>
-            <outputDirectory></outputDirectory>
+            <outputDirectory>/</outputDirectory>
         </fileSet>
     </fileSets>
 </assembly>

--- a/src/main/archetype/ui.frontend.angular/assembly.xml
+++ b/src/main/archetype/ui.frontend.angular/assembly.xml
@@ -10,7 +10,7 @@
             <includes>
                 <include>**/*</include>
             </includes>
-            <outputDirectory></outputDirectory>
+            <outputDirectory>/</outputDirectory>
         </fileSet>
     </fileSets>
 </assembly>

--- a/src/main/archetype/ui.frontend.general/assembly.xml
+++ b/src/main/archetype/ui.frontend.general/assembly.xml
@@ -12,7 +12,7 @@
             <includes>
                 <include>**/*</include>
             </includes>
-            <outputDirectory></outputDirectory>
+            <outputDirectory>/</outputDirectory>
         </fileSet>
     </fileSets>
 </assembly>

--- a/src/main/archetype/ui.frontend.react.forms.af/assembly.xml
+++ b/src/main/archetype/ui.frontend.react.forms.af/assembly.xml
@@ -10,7 +10,7 @@
             <includes>
                 <include>**/*</include>
             </includes>
-            <outputDirectory></outputDirectory>
+            <outputDirectory>/</outputDirectory>
         </fileSet>
     </fileSets>
 </assembly>

--- a/src/main/archetype/ui.frontend.react/assembly.xml
+++ b/src/main/archetype/ui.frontend.react/assembly.xml
@@ -10,7 +10,7 @@
             <includes>
                 <include>**/*</include>
             </includes>
-            <outputDirectory></outputDirectory>
+            <outputDirectory>/</outputDirectory>
         </fileSet>
     </fileSets>
 </assembly>


### PR DESCRIPTION
I'm replacing `<outputDirectory></outputDirectory>` with `<outputDirectory>/</outputDirectory>` where `/` is explicitly set.

## Motivation and Context

Empty `<outputDirectory></outputDirectory>` does work, but is confusing... Even if it does work, we can easily be more specific and clear here.

It's an issue with assembly itself of course. Empty configuration has a different effect from no configuration. That does not feel natural here IMO.

## How Has This Been Tested?

Tested locally on my current project.