### PR TITLE
fix broken link in archetype README

### DIFF
--- a/src/main/archetype/README.md
+++ b/src/main/archetype/README.md
@@ -121,4 +121,4 @@ A ClientLib will consist of the following files and directories:
 
 The project comes with the auto-public repository configured. To setup the repository in your Maven settings, refer to:
 
-    http://helpx.adobe.com/experience-manager/kb/SetUpTheAdobeMavenRepository.html
+    https://experienceleague.adobe.com/en/docs/experience-cloud-kcs/kbarticles/ka-17454


### PR DESCRIPTION
Fixes the broken link in the "Maven settings" section of the generated README

## Description

Changed the following [line](https://github.com/adobe/aem-project-archetype/blob/582722e05b2661ce28b64f07672b866644f998e0/src/main/archetype/README.md?plain=1#L124) with a valid link to the [documentation](https://experienceleague.adobe.com/en/docs/experience-cloud-kcs/kbarticles/ka-17454)

## Related Issue

Issue: #1294 

## Motivation and Context

Provide the correct information to other developers working on an AEM project.

## How Has This Been Tested?

N/A

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.