### PR TITLE
Remove outdated dependency junit-addons

### DIFF
--- a/src/main/archetype/core/pom.xml
+++ b/src/main/archetype/core/pom.xml
@@ -241,11 +241,6 @@ Import-Package: javax.annotation;version=0.0.0,*
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit-addons</groupId>
-            <artifactId>junit-addons</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.wcm</groupId>
             <artifactId>io.wcm.testing.aem-mock.junit5</artifactId>
             <scope>test</scope>

--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -949,12 +949,6 @@ Bundle-DocURL:
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>junit-addons</groupId>
-                <artifactId>junit-addons</artifactId>
-                <version>1.4</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>io.wcm</groupId>
                 <artifactId>io.wcm.testing.aem-mock.junit5</artifactId>
                 <version>5.5.4</version>


### PR DESCRIPTION
## Description

remove this dependency from parent POM and core module:

```
            <dependency>
                <groupId>junit-addons</groupId>
                <artifactId>junit-addons</artifactId>
                <version>1.4</version>
                <scope>test</scope>
            </dependency>
```

## Related Issue

Fixes #920 

## Motivation and Context

this dependency is completely outdated (more than 20 years old!!), it's not compatible/usable with JUnit 5+, and even worse, it breaks JSON content loading when using AEM mocks, as it injects an outdated Xerces version into the test build classpath (as described in #920). it should be removed without replacement.

## How Has This Been Tested?

the archetype build including its ITs is passing without this dependency.
