### PR TITLE
@releng update CIF dependencies to latest releases

### DIFF
--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -76,7 +76,7 @@
 #end
         <core.wcm.components.version>2.28.0</core.wcm.components.version>
 #if ( $includeCif == "y" )
-        <core.cif.components.version>2.18.0</core.cif.components.version>
+        <core.cif.components.version>2.18.2</core.cif.components.version>
         <magento.graphql.version>9.1.0-magento242ee</magento.graphql.version>
         <aem.cif.sdk.api>2025.09.02.00</aem.cif.sdk.api>
 #end


### PR DESCRIPTION
## Summary
- update archetype CIF dependency version to 2.18.2

## Related Issue
- SITES-42445

## Testing
- not run (dependency-only change)