### PR TITLE
chore: upgrade actions/setup-java to v4 and fix JAVA_HOME path issue

### DIFF
--- a/.github/workflows/maven-deploy-cm.yml
+++ b/.github/workflows/maven-deploy-cm.yml
@@ -43,7 +43,7 @@ jobs:
           path: archetype
       # Set up JDK 11
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '11'

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -28,9 +28,10 @@ jobs:
 
       # Set up environment with Java and Maven
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 11
+          distribution: 'temurin'
 
       # Set up dependency cache
       - name: Cache local Maven repository

--- a/.github/workflows/maven-sdk-update.yml
+++ b/.github/workflows/maven-sdk-update.yml
@@ -40,9 +40,10 @@ jobs:
           path: archetype
       # Set up environment with Java and Maven
       - name: Setup JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'temurin'
       # Set up dependency cache
       - name: Cache local Maven repository
         uses: actions/cache@v4

--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -40,9 +40,10 @@ jobs:
 
       # Set up environment with Java and Maven
       - name: Setup JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'temurin'
 
       # Set up dependency cache
       - name: Cache local Maven repository


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Workflow was failing during the Maven execution step with the error:
```
The JAVA_HOME environment variable is not defined correctly.
```
This was caused by the use of the deprecated actions/setup-java@v1. While the $JAVA_HOME variable appeared correctly when using echo, the older action failed to properly export the environment variable to the system path in a way that modern GitHub-hosted runners (specifically macOS and Windows) could consume. This created a mismatch where the shell knew where Java was, but Maven did not.