### PR TITLE
chore: migrate Maven deployment from OSSRH to Maven Central Portal

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -62,8 +62,8 @@ jobs:
       - name: Release to Central Repository
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           X_GITHUB_USERNAME: ${{ secrets.ADOBE_BOT_GITHUB_USERNAME  }}
           X_GITHUB_PASSWORD: ${{ secrets.ADOBE_BOT_GITHUB_PASSWORD }}
         run: mvn -B clean release:prepare release:perform -Prelease,central,it-basic -s ./.github/workflows/settings.xml

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -58,12 +58,12 @@ jobs:
           git config user.email "Grp-opensourceoffice@adobe.com"
           git config user.name "${X_GITHUB_USERNAME}"
 
-      # Deploy to OSSRH, which will automatically release to Central Repository
+      # Build and deploy to Central Repository
       - name: Release to Central Repository
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           X_GITHUB_USERNAME: ${{ secrets.ADOBE_BOT_GITHUB_USERNAME  }}
           X_GITHUB_PASSWORD: ${{ secrets.ADOBE_BOT_GITHUB_PASSWORD }}
-        run: mvn -B clean release:prepare release:perform -Prelease,ossrh,it-basic -s ./.github/workflows/settings.xml
+        run: mvn -B clean release:prepare release:perform -Prelease,central,it-basic -s ./.github/workflows/settings.xml

--- a/.github/workflows/settings.xml
+++ b/.github/workflows/settings.xml
@@ -18,15 +18,15 @@
 
     <profiles>
         <profile>
-            <id>ossrh</id>
+            <id>central</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <releaseRepository-Id>ossrh</releaseRepository-Id>
-                <releaseRepository-URL>https://oss.sonatype.org/service/local/staging/deploy/maven2/</releaseRepository-URL>
-                <snapshotRepository-Id>ossrh</snapshotRepository-Id>
-                <snapshotRepository-URL>https://oss.sonatype.org/content/repositories/snapshots</snapshotRepository-URL>
+                <releaseRepository-Id>central</releaseRepository-Id>
+                <releaseRepository-URL>https://central.sonatype.com/repository/maven-releases/</releaseRepository-URL>
+                <snapshotRepository-Id>central</snapshotRepository-Id>
+                <snapshotRepository-URL>https://central.sonatype.com/repository/maven-snapshots/</snapshotRepository-URL>
                 <project.scm.id>github</project.scm.id>
                 <gpg.executable>gpg</gpg.executable>
                 <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
@@ -36,14 +36,14 @@
 
     <servers>
         <server>
-            <id>ossrh</id>
-            <username>${env.SONATYPE_USERNAME}</username>
-            <password>${env.SONATYPE_PASSWORD}</password>
-        </server>
-        <server>
             <id>github</id>
             <username>${env.X_GITHUB_USERNAME}</username>
             <password>${env.X_GITHUB_PASSWORD}</password>
+        </server>
+        <server>
+            <id>central</id>
+            <username>${env.MAVEN_CENTRAL_USERNAME}</username>
+            <password>${env.MAVEN_CENTRAL_PASSWORD}</password>
         </server>
     </servers>
 

--- a/.github/workflows/settings.xml
+++ b/.github/workflows/settings.xml
@@ -42,8 +42,8 @@
         </server>
         <server>
             <id>central</id>
-            <username>${env.MAVEN_CENTRAL_USERNAME}</username>
-            <password>${env.MAVEN_CENTRAL_PASSWORD}</password>
+            <username>${env.SONATYPE_USERNAME}</username>
+            <password>${env.SONATYPE_PASSWORD}</password>
         </server>
     </servers>
 

--- a/pom.xml
+++ b/pom.xml
@@ -203,14 +203,13 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.7</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.8.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
## Summary
- Replace `org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7` with `org.sonatype.central:central-publishing-maven-plugin:0.8.0` in the `release` profile.
- Switch the `.github/workflows/settings.xml` profile and server id from `ossrh` to `central` and point at `https://central.sonatype.com/repository/maven-{releases,snapshots}/`.
- Rename the credential env vars from `SONATYPE_USERNAME`/`SONATYPE_PASSWORD` to `MAVEN_CENTRAL_USERNAME`/`MAVEN_CENTRAL_PASSWORD` in `maven-release.yml` and `settings.xml`, and switch the active Maven profile from `ossrh` to `central`.

OSSRH (`oss.sonatype.org`) is decommissioned per <https://central.sonatype.org/pages/ossrh-eol/>; this mirrors the migration applied in adobe/aem-core-wcm-components#2977.

The Release workflow on release/57 has been failing with `401 Unauthorized` against `https://oss.sonatype.org/` ([run](https://github.com/adobe/aem-project-archetype/actions/runs/25543667262)). A parallel cherry-pick of this commit has been opened against `release/57` to unblock the v57 release.

> [!IMPORTANT]
> Requires the org-level secrets `MAVEN_CENTRAL_USERNAME` and `MAVEN_CENTRAL_PASSWORD` to be populated with valid Central Portal user-tokens for the `com.adobe.aem` namespace before this can publish successfully.

## Test plan
- [ ] Confirm `MAVEN_CENTRAL_USERNAME` / `MAVEN_CENTRAL_PASSWORD` org secrets exist (with OSPO)
- [ ] Trigger the Release workflow on release/57 (after the companion PR is merged) and verify deploy to `central.sonatype.com` succeeds