### PR TITLE
SITES-45016 - Release CIF components 2.18.4

### DIFF
--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -76,7 +76,7 @@
 #end
         <core.wcm.components.version>2.28.0</core.wcm.components.version>
 #if ( $includeCif == "y" )
-        <core.cif.components.version>2.18.2</core.cif.components.version>
+        <core.cif.components.version>2.18.4</core.cif.components.version>
         <magento.graphql.version>9.1.0-magento242ee</magento.graphql.version>
         <aem.cif.sdk.api>2025.09.02.00</aem.cif.sdk.api>
 #end


### PR DESCRIPTION
## Description

Bump the AEM CIF Core Components dependency in the archetype's `cif` profile to **2.18.4**.

* `src/main/archetype/pom.xml`: `core.cif.components.version` 2.18.2 → 2.18.4 inside the `#if ( $includeCif == "y" )` block.

## Related Issue

SITES-45016

## Verification

`2.18.4` artifacts have been verified on Maven Central:
`https://repo1.maven.org/maven2/com/adobe/commerce/cif/core-cif-components-all/2.18.4/`


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author