### PR TITLE
Add X-Aem-Canary to default client headers

### DIFF
--- a/src/main/archetype/dispatcher.cloud/src/conf.dispatcher.d/clientheaders/default_clientheaders.any
+++ b/src/main/archetype/dispatcher.cloud/src/conf.dispatcher.d/clientheaders/default_clientheaders.any
@@ -42,3 +42,4 @@
 "If-Modified-Since"
 "Authorization"
 "x-request-id"
+"X-Aem-Canary"


### PR DESCRIPTION
Prevent request from being blocked by dispatcher

Allow requests with X-Aem-Canary header to be allowed by dispatcher

