### PR TITLE
Add 'X-Aem-Canary' to client headers

### DIFF
--- a/src/main/archetype/dispatcher.cloud/src/conf.dispatcher.d/clientheaders/default_clientheaders.any
+++ b/src/main/archetype/dispatcher.cloud/src/conf.dispatcher.d/clientheaders/default_clientheaders.any
@@ -42,3 +42,4 @@
 "If-Modified-Since"
 "Authorization"
 "x-request-id"
+"X-Aem-Canary"


### PR DESCRIPTION
## Description

Allow for requests with X-Aem-Canary in the header to be allowed by the dispatcher.