### PR TITLE
SITES-49657 - Release CIF components 2.18.8

### DIFF
--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -69,7 +69,7 @@
         <frontend-maven-plugin.version>1.12.0</frontend-maven-plugin.version>
         <core.wcm.components.version>2.28.0</core.wcm.components.version>
 #if ( $includeCif == "y" )
-        <core.cif.components.version>2.18.4</core.cif.components.version>
+        <core.cif.components.version>2.18.8</core.cif.components.version>
         <magento.graphql.version>9.1.0-magento242ee</magento.graphql.version>
         <aem.cif.sdk.api>2025.09.02.00</aem.cif.sdk.api>
 #end


### PR DESCRIPTION
## Description

Bump the AEM CIF Core Components version in the archetype's generated project POM to **2.18.8**.

* `src/main/archetype/pom.xml`: `core.cif.components.version` 2.18.4 → 2.18.8 inside the `$includeCif == "y"` profile

## Related Issue

SITES-49657

## Verification

2.18.8 artifacts have been verified on Maven Central. The change is confined to the CIF property in the archetype POM template; no other archetype property or module is affected.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author